### PR TITLE
🐛 ⚒️ - Fixing devx nits

### DIFF
--- a/src/components/ActiveDatesCard/ActiveDatesCard.tsx
+++ b/src/components/ActiveDatesCard/ActiveDatesCard.tsx
@@ -26,7 +26,7 @@ export interface ActiveDatesCardProps {
   endDate: Field<DateTime | null>;
 
   /**
-   * The shop's time zone abbreviation.
+   * The shop's time zone abbreviation. This can be queried from the [Shop gql object](https://shopify.dev/api/admin-graphql/2022-07/objects/Shop#field-shop-timezoneabbreviation).
    */
   timezoneAbbreviation: string;
 
@@ -110,7 +110,7 @@ export function ActiveDatesCard({
   };
 
   const endDateIsStartDate =
-    endDate.value !== null &&
+    endDate.value &&
     isSameDay(new Date(endDate.value), new Date(startDate.value));
 
   const disableEndDatesBefore = getEndDatePickerDisableDatesBefore(
@@ -164,7 +164,7 @@ export function ActiveDatesCard({
           />
         </FormLayout.Group>
 
-        {showEndDate && endDate.value !== null && (
+        {showEndDate && endDate.value && (
           <FormLayout.Group>
             <DatePicker
               date={{
@@ -220,7 +220,7 @@ function initShowEndDate(
 ) {
   if (!endDate.value) {
     return false;
-  } else if (endDate.value !== null && endDate.error) {
+  } else if (endDate.value && endDate.error) {
     return true;
   }
 

--- a/src/components/AppProvider/AppProvider.tsx
+++ b/src/components/AppProvider/AppProvider.tsx
@@ -12,7 +12,7 @@ export interface AppProviderProps {
   locale: string;
 
   /**
-   * The shop's time zone as defined by the IANA (e.g. `America/Los_Angeles`).
+   * The shop's time zone as defined by the IANA (e.g. `America/Los_Angeles`). This can be queried from the [Shop gql object](https://shopify.dev/api/admin-graphql/2022-07/objects/Shop#field-shop-ianatimezone).
    */
   ianaTimezone: string;
 

--- a/src/components/MethodCard/MethodCard.tsx
+++ b/src/components/MethodCard/MethodCard.tsx
@@ -86,8 +86,8 @@ export function MethodCard({
       <Card.Section
         title={
           discountMethodHidden
-            ? i18n.translate('DiscountAppComponents.MethodCard.methodSubtitle')
-            : undefined
+            ? undefined
+            : i18n.translate('DiscountAppComponents.MethodCard.methodSubtitle')
         }
       >
         <Stack vertical>

--- a/src/components/MethodCard/tests/MethodCard.test.tsx
+++ b/src/components/MethodCard/tests/MethodCard.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {ChoiceList, Heading, TextField} from '@shopify/polaris';
+import {Card, ChoiceList, Heading, TextField} from '@shopify/polaris';
 import {mockField, mountWithApp} from 'tests/utilities';
 
 import {MethodCard} from '../MethodCard';
@@ -97,6 +97,9 @@ describe('<MethodCard />', () => {
       />,
     );
     expect(methodCard).not.toContainReactComponent(ChoiceList);
+    expect(methodCard).not.toContainReactComponent(Card.Section, {
+      title: 'Method',
+    });
   });
 
   it('renders discountMethod choice list when discountMethodHidden is false', () => {
@@ -110,6 +113,9 @@ describe('<MethodCard />', () => {
       />,
     );
     expect(methodCard).toContainReactComponent(ChoiceList);
+    expect(methodCard).toContainReactComponent(Card.Section, {
+      title: 'Method',
+    });
   });
 
   it('toggling the discount method calls onChange for the discountMethod', () => {


### PR DESCRIPTION
## Description
- Updated ActiveDates endDate check to be for `falsy` instead of null. This doesn't reduce the integrity of the checks but also doesn't crash the page if a user passes undefined by mistake.
- Added prop comments that point devs to the Shop gql api
- Updated MethodCard logic for hiding/showing the 'method' section title.

## 🎩 
- Clone this repo
- Run `yarn storybook`
- Verify that the `method` section title doesn't appear when `discountMethodHidden` is set
