### PR TITLE
Remove shipit buildkite step

### DIFF
--- a/shipit.package.yml
+++ b/shipit.package.yml
@@ -1,3 +1,0 @@
-ci:
-  require:
-    - buildkite/discount-app-components


### PR DESCRIPTION
## Description
We no longer need the buildkite step for the package deploy since the gh CI action [replaces the functionality](https://github.com/Shopify/discount-app-components/pull/14)