### PR TITLE
ci: add release action and scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Create release Pull Request or publish to NPM
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          version: yarn version
+          publish: yarn release
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: yarn --frozen-lockfile
 
-      - name: Create release Pull Request or publish to NPM
+      - name: Create release pr or publish new tag
         id: changesets
         uses: changesets/action@v1
         with:

--- a/README.md
+++ b/README.md
@@ -143,8 +143,10 @@ You may need to update your webpack.config.js to include a `module.rules` of:
 ```
 
 ### Releasing
+
 ### New version and releasing
+
 1. When feature work is merged into main there is a release GitHub action which will run.
-2. It runs  `yarn version` and incorporates the changesets into the changelog.
+2. It runs `yarn version` and incorporates the changesets into the changelog.
 3. It bumps the version accordingly. If changesets contain minor changes then the minor version is bumped.
 4. The release action runs `yarn release`, which runs the `tag` command because we are using a different tool (Shipit), to publish our package. It creates a vX.X.X tag, which can then be picked up by Shipit.

--- a/README.md
+++ b/README.md
@@ -141,3 +141,10 @@ You may need to update your webpack.config.js to include a `module.rules` of:
   type: 'javascript/auto',
 }
 ```
+
+### Releasing
+### New version and releasing
+1. When feature work is merged into main there is a release GitHub action which will run.
+2. It runs  `yarn version` and incorporates the changesets into the changelog.
+3. It bumps the version accordingly. If changesets contain minor changes then the minor version is bumped.
+4. The release action runs `yarn release`, which runs the `tag` command because we are using a different tool (Shipit), to publish our package. It creates a vX.X.X tag, which can then be picked up by Shipit.

--- a/package.json
+++ b/package.json
@@ -53,7 +53,10 @@
     "build": "node ./scripts/build.js",
     "preyalcpublish": "npm-run-all clean build",
     "prepare": "npm-run-all clean build",
-    "storybook": "yarn start-storybook"
+    "storybook": "yarn start-storybook",
+    "changeset": "changeset",
+    "version": "changeset version",
+    "release": "changeset tag"
   },
   "dependencies": {
     "@shopify/admin-graphql-api-utilities": "^2.0.0",


### PR DESCRIPTION
This PR adds a GH action which watches merges to the main branch. It creates a new version when changesets are detected and bumps the version accordingly.

### Typical flow:
#### Feature work
1. Changes are made in a working branch and it is deemed that a version (patch/minor/major) bump is needed.
2. On the working branch run `yarn changeset` and completes the prompts.
3. Then push the generated changesets to your working branch.
4. Merge working branch as you would normally, after getting reviews and CI passes.

### New version and releasing
1. When feature work is merged into main there is a release GitHub action which will run. 
2. It runs  `yarn version` and incorporates the changesets into the changelog.
3. It bumps the version accordingly. If changesets contain minor changes then the minor version is bumped.
4. The release action runs `yarn release`, which runs the `tag` command because we are using a different tool (Shipit), to publish our package. It creates a vX.X.X tag, which can then be picked up by Shipit.

> The tag command creates git tags for the current version of all packages. The tags created are equivalent to those created by [changeset publish](https://github.com/changesets/changesets/blob/main/docs/command-line-options.md#publish), but the tag command does not publish anything to npm.
> 
> This is helpful in situations where a different tool, such as pnpm publish -r, is used to publish packages instead of changeset. For situations where changeset publish is executed, running changeset tag is not needed.
> 
> The git tags in monorepos are created in the format pkg-name@version-number and are based on the current version number of the package.json for each package. Note that in single-package repositories, the git tag will include v before the version number, for example, v1.0.0. It is expected that [changeset version](https://github.com/changesets/changesets/blob/main/docs/command-line-options.md#version) is run before changeset tag, so the package.json versions are updated before the git tags are created. 

**Safety check**: when running without any version bumps: 

![image](https://user-images.githubusercontent.com/9765013/187923751-fb549766-c461-4a05-8b45-d86d5c5a1586.png)
