### PR TITLE
docs: update readme with app provider links

### DIFF
--- a/.changeset/pink-bugs-clean.md
+++ b/.changeset/pink-bugs-clean.md
@@ -1,0 +1,5 @@
+---
+'@shopify/discount-app-components': patch
+---
+
+update readme with app provider links

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ yarn add @shopify/discount-app-components
     />
     ```
 
-2.  This library contains a number of locale-specific components, and you will be required to pass a `locale` and a `ianaTimezone` to the discounts AppProvider. Also, this library will require you to wrap your app in a Polaris AppProvider and an AppBridge AppProvider. A full example of an app root can be found below:
+2.  This library contains a number of locale-specific components, and you will be required to pass a `locale` and a `ianaTimezone` to the discounts AppProvider. Also, this library will require you to wrap your app in a [Polaris AppProvider](https://polaris.shopify.com/components/app-provider) and an [AppBridge AppProvider](https://shopify.dev/apps/tools/app-bridge/getting-started/using-react#provider). A full example of an app root can be found below:
 
     ```js
     import {Page, AppProvider as PolarisAppProvider} from '@shopify/polaris';


### PR DESCRIPTION
Updating the readme to provide links to Polaris and App Bridge providers.

This PR also serves to kick off changelog and version release automation.

In theory, once this PR is merged the patch version will be bumped. And the release process can be started.