### PR TITLE
ci: use gaap token for gh actions

### DIFF
--- a/.changeset/bright-drinks-type.md
+++ b/.changeset/bright-drinks-type.md
@@ -1,0 +1,5 @@
+---
+'@shopify/discount-app-components': patch
+---
+
+use gaap to provide secrets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,5 +30,5 @@ jobs:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: yarn release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PROMOTE_GH_ACCESS_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
**Do not merge this PR until the linked [PR](https://github.com/Shopify/github-actions-access-provider/pull/128) is merged** 

** AND ** Wait for the workflow to rotate the secrets to have run once. 

We've onboarded the repo on [GAAP](https://github.com/Shopify/github-actions-access-provider/pull/128) - which will provide repo specific access tokens to our gh actions. This should allow CI actions to run on GH. GitHub actions are not meant to run in succession when triggered by eachother. (Limits possibility of getting into a action loop or abuse).