### PR TITLE
fix: update Polaris style guide links

### DIFF
--- a/.changeset/few-radios-listen.md
+++ b/.changeset/few-radios-listen.md
@@ -1,0 +1,5 @@
+---
+'@shopify/discount-app-components': patch
+---
+
+Update Polaris style guide links

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ yarn add @shopify/discount-app-components
     />
     ```
 
-2.  This library contains a number of locale-specific components, and you will be required to pass a `locale` and a `ianaTimezone` to the discounts AppProvider. Also, this library will require you to wrap your app in a [Polaris AppProvider](https://polaris.shopify.com/components/app-provider) and an [AppBridge AppProvider](https://shopify.dev/apps/tools/app-bridge/getting-started/using-react#provider). A full example of an app root can be found below:
+2.  This library contains a number of locale-specific components, and you will be required to pass a `locale` and a `ianaTimezone` to the discounts AppProvider. Also, this library will require you to wrap your app in a [Polaris AppProvider](https://polaris.shopify.com/components/utilities/app-provider) and an [AppBridge AppProvider](https://shopify.dev/apps/tools/app-bridge/getting-started/using-react#provider). A full example of an app root can be found below:
 
     ```js
     import {Page, AppProvider as PolarisAppProvider} from '@shopify/polaris';

--- a/src/components/DatePicker/README.md
+++ b/src/components/DatePicker/README.md
@@ -2,7 +2,7 @@
 
 The DatePicker component provides an input that allows users to select a date from a calendar popover or enter one into a text input.
 
-The calendar is powered by a [Polaris DatePicker](https://polaris.shopify.com/components/forms/date-picker) under the hood.
+The calendar is powered by a [Polaris DatePicker](https://polaris.shopify.com/components/selection-and-input/date-picker) under the hood.
 
 ---
 

--- a/src/components/TimePicker/utilities.ts
+++ b/src/components/TimePicker/utilities.ts
@@ -109,7 +109,7 @@ export function isValidTime(time?: string) {
 }
 
 /**
- * Given a list of dates, returns a list of options that can be used by a {@link https://polaris.shopify.com/components/forms/select| @shopify/polaris select}
+ * Given a list of dates, returns a list of options that can be used by a {@link https://polaris.shopify.com/components/selection-and-input/select| @shopify/polaris select}
  *
  * @param dates - List of dates to convert to options
  * @param locale - Locale to use for date formatting


### PR DESCRIPTION
Part of [Polaris#8185](https://github.com/Shopify/polaris/issues/8185).
The Polaris style guide was updated with new groupings for components. This PR updates the component links to reflect those changes.