### PR TITLE
patch a bug trying to load translations file with vite

### DIFF
--- a/src/components/AppProvider/AppProvider.tsx
+++ b/src/components/AppProvider/AppProvider.tsx
@@ -1,5 +1,5 @@
-import React, {useMemo} from 'react';
 import {I18nContext, I18nManager} from '@shopify/react-i18n';
+import React, {useMemo} from 'react';
 
 import {DiscountsI18nProvider} from './components';
 
@@ -15,6 +15,8 @@ export interface AppProviderProps {
    * The shop's time zone as defined by the IANA (e.g. `America/Los_Angeles`). This can be queried from the [Shop gql object](https://shopify.dev/api/admin-graphql/2022-07/objects/Shop#field-shop-ianatimezone).
    */
   ianaTimezone: string;
+
+  translationsFn?: (locale: string) => Promise<any>;
 
   children?: React.ReactNode;
 }
@@ -40,7 +42,9 @@ export function AppProvider(props: AppProviderProps) {
 
   return (
     <I18nContext.Provider value={i18nManager}>
-      <DiscountsI18nProvider>{props.children}</DiscountsI18nProvider>
+      <DiscountsI18nProvider translationsFn={props.translationsFn}>
+        {props.children}
+      </DiscountsI18nProvider>
     </I18nContext.Provider>
   );
 }

--- a/src/components/AppProvider/components/DiscountsI18nProvider/DiscountsI18nProvider.tsx
+++ b/src/components/AppProvider/components/DiscountsI18nProvider/DiscountsI18nProvider.tsx
@@ -2,20 +2,32 @@ import React from 'react';
 import {useI18n} from '@shopify/react-i18n';
 import defaultTranslations from '@locales/en.json';
 
-export function DiscountsI18nProvider({children}: {children: React.ReactNode}) {
+async function DEFAULT_TRANSLATIONS_FN(locale: string) {
+  return import(
+    /* webpackChunkName: "DiscountAppComponents-i18n", webpackMode: "lazy-once" */ `locales_dynamic/${locale}.json`
+    ).then((dictionary) => {
+    if (!dictionary) {
+      return undefined;
+    }
+
+    return dictionary.default;
+  });
+}
+
+export function DiscountsI18nProvider({
+                                        children,
+                                        translationsFn,
+                                      }: {
+  children: React.ReactNode;
+  translationsFn?: (locale: string) => Promise<any>;
+}) {
   const [, ShareTranslations] = useI18n({
     id: 'DiscountAppComponents',
     fallback: defaultTranslations,
     async translations(locale) {
-      return import(
-        /* webpackChunkName: "DiscountAppComponents-i18n", webpackMode: "lazy-once" */ `locales_dynamic/${locale}.json`
-      ).then((dictionary) => {
-        if (!dictionary) {
-          return undefined;
-        }
-
-        return dictionary.default;
-      });
+      return typeof translationsFn === 'function'
+        ? translationsFn(locale)
+        : DEFAULT_TRANSLATIONS_FN(locale);
     },
   });
 


### PR DESCRIPTION
https://github.com/Shopify/discount-app-components/issues/60#issuecomment-1537062292

### Usage

```
import { AppProvider } from '@shopify/discount-app-components';

// The exact path for these will depend where your node_modules is.
// This example assumes the SomeComponent file lives in the root-project-folder/src/components folder.
const LOCALES = import.meta.glob('../../node_modules/@shopify/discount-app-components/locales/*.json');

function discountTranslations(locale) {
     return LOCALES[`../../node_modules/@shopify/discount-app-components/locales/${locale}.json`]();
}

export default function SomeComponent({ locale, timezone, children }) {
     return (
        <AppProvider locale={locale} ianaTimezone={timezone} translationsFn={discountTranslations}>
            {children}
        </AppProvider>
    );
}
```