### PR TITLE
Update SummaryCard.Combinations to handle all combinations selected

### DIFF
--- a/.changeset/moody-files-rest.md
+++ b/.changeset/moody-files-rest.md
@@ -1,0 +1,5 @@
+---
+'@shopify/discount-app-components': patch
+---
+
+Add support for discount stacking in Summary Card.

--- a/locales/en.json
+++ b/locales/en.json
@@ -216,7 +216,8 @@
           "productAndOrder": "Combines with product and order discounts",
           "productAndShipping": "Combines with product and shipping discounts",
           "orderAndShipping": "Combines with order and shipping discounts"
-        }
+        },
+        "combinesAll": "Combines with product, order, and shipping discounts"
       },
       "CustomerEligibility": {
         "allCustomers": "All customers",

--- a/src/components/SummaryCard/components/Combinations/Combinations.tsx
+++ b/src/components/SummaryCard/components/Combinations/Combinations.tsx
@@ -42,6 +42,8 @@ function getContent(combinations: DiscountClass[], i18n: I18n) {
         )}`,
         I18N_SCOPE,
       );
+    case 3:
+      return i18n.translate(`combinesAll`, I18N_SCOPE);
     default:
       return '';
   }

--- a/src/components/SummaryCard/components/Combinations/tests/Combinations.test.tsx
+++ b/src/components/SummaryCard/components/Combinations/tests/Combinations.test.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-
 import {Combinations} from '../Combinations';
-
-import {DiscountClass} from '~/constants';
 
 describe('<Combinations />', () => {
   it('renders nothing when no combination options are set', () => {
@@ -21,17 +18,21 @@ describe('<Combinations />', () => {
   });
 
   it.each`
-    combinesWithProduct | combinesWithOrder | combinesWithShipping | selectedCombinations
-    ${true}             | ${false}          | ${false}             | ${[DiscountClass.Product]}
-    ${false}            | ${true}           | ${false}             | ${[DiscountClass.Order]}
-    ${false}            | ${false}          | ${true}              | ${[DiscountClass.Shipping]}
+    combinesWithProduct | combinesWithOrder | combinesWithShipping | expectedText
+    ${true}             | ${true}           | ${true}              | ${`Combines with product, order, and shipping discounts`}
+    ${true}             | ${true}           | ${false}             | ${`Combines with product and order discounts`}
+    ${true}             | ${false}          | ${true}              | ${`Combines with product and shipping discounts`}
+    ${false}            | ${true}           | ${true}              | ${`Combines with order and shipping discounts`}
+    ${true}             | ${false}          | ${false}             | ${`Combines with product discounts`}
+    ${false}            | ${true}           | ${false}             | ${`Combines with order discounts`}
+    ${false}            | ${false}          | ${true}              | ${`Combines with shipping discounts`}
   `(
-    'renders combination summary when one combination option is set',
+    'renders combination summary when at least one combination option is set',
     ({
       combinesWithProduct,
       combinesWithOrder,
       combinesWithShipping,
-      selectedCombinations,
+      expectedText,
     }) => {
       const combinations = mountWithApp(
         <Combinations
@@ -43,65 +44,7 @@ describe('<Combinations />', () => {
         />,
       );
 
-      expect(combinations).toContainReactText(
-        `Combines with ${selectedCombinations[0].toLowerCase()} discounts`,
-      );
-    },
-  );
-
-  it.each`
-    combinesWithProduct | combinesWithOrder | combinesWithShipping | selectedCombinations
-    ${true}             | ${true}           | ${false}             | ${[DiscountClass.Product, DiscountClass.Order]}
-    ${true}             | ${false}          | ${true}              | ${[DiscountClass.Product, DiscountClass.Shipping]}
-    ${false}            | ${true}           | ${true}              | ${[DiscountClass.Order, DiscountClass.Shipping]}
-  `(
-    'renders combination summary when two combination options are set',
-    ({
-      combinesWithProduct,
-      combinesWithOrder,
-      combinesWithShipping,
-      selectedCombinations,
-    }) => {
-      const combinations = mountWithApp(
-        <Combinations
-          combinesWith={{
-            productDiscounts: combinesWithProduct,
-            orderDiscounts: combinesWithOrder,
-            shippingDiscounts: combinesWithShipping,
-          }}
-        />,
-      );
-
-      expect(combinations).toContainReactText(
-        `Combines with ${selectedCombinations[0].toLowerCase()} and ${selectedCombinations[1].toLowerCase()} discounts`,
-      );
-    },
-  );
-
-  it.each`
-    combinesWithProduct | combinesWithOrder | combinesWithShipping | selectedCombinations
-    ${true}             | ${true}           | ${true}              | ${[DiscountClass.Product, DiscountClass.Order, DiscountClass.Shipping]}
-  `(
-    'renders combination summary when three combination options are set',
-    ({
-      combinesWithProduct,
-      combinesWithOrder,
-      combinesWithShipping,
-      selectedCombinations,
-    }) => {
-      const combinations = mountWithApp(
-        <Combinations
-          combinesWith={{
-            productDiscounts: combinesWithProduct,
-            orderDiscounts: combinesWithOrder,
-            shippingDiscounts: combinesWithShipping,
-          }}
-        />,
-      );
-
-      expect(combinations).toContainReactText(
-        `Combines with ${selectedCombinations[0].toLowerCase()}, ${selectedCombinations[1].toLowerCase()}, and ${selectedCombinations[2].toLowerCase()} discounts`,
-      );
+      expect(combinations).toContainReactText(expectedText);
     },
   );
 });

--- a/src/components/SummaryCard/components/Combinations/tests/Combinations.test.tsx
+++ b/src/components/SummaryCard/components/Combinations/tests/Combinations.test.tsx
@@ -3,22 +3,9 @@ import {mountWithApp} from 'tests/utilities';
 import {Combinations} from '../Combinations';
 
 describe('<Combinations />', () => {
-  it('renders nothing when no combination options are set', () => {
-    const combinations = mountWithApp(
-      <Combinations
-        combinesWith={{
-          orderDiscounts: false,
-          productDiscounts: false,
-          shippingDiscounts: false,
-        }}
-      />,
-    );
-
-    expect(combinations.find(Combinations)).toBeNull();
-  });
-
   it.each`
     combinesWithProduct | combinesWithOrder | combinesWithShipping | expectedText
+    ${false}            | ${false}          | ${false}             | ${`Can't combine with other discounts`}
     ${true}             | ${true}           | ${true}              | ${`Combines with product, order, and shipping discounts`}
     ${true}             | ${true}           | ${false}             | ${`Combines with product and order discounts`}
     ${true}             | ${false}          | ${true}              | ${`Combines with product and shipping discounts`}
@@ -27,7 +14,7 @@ describe('<Combinations />', () => {
     ${false}            | ${true}           | ${false}             | ${`Combines with order discounts`}
     ${false}            | ${false}          | ${true}              | ${`Combines with shipping discounts`}
   `(
-    'renders combination summary when at least one combination option is set',
+    'renders the summary when combinesWith `product: $combinesWithProduct, order: $combinesWithOrder, shipping: $combinesWithShipping`',
     ({
       combinesWithProduct,
       combinesWithOrder,

--- a/src/components/SummaryCard/components/Combinations/tests/Combinations.test.tsx
+++ b/src/components/SummaryCard/components/Combinations/tests/Combinations.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
+
 import {Combinations} from '../Combinations';
 
 describe('<Combinations />', () => {

--- a/src/components/SummaryCard/components/Combinations/tests/Combinations.test.tsx
+++ b/src/components/SummaryCard/components/Combinations/tests/Combinations.test.tsx
@@ -77,4 +77,31 @@ describe('<Combinations />', () => {
       );
     },
   );
+
+  it.each`
+    combinesWithProduct | combinesWithOrder | combinesWithShipping | selectedCombinations
+    ${true}             | ${true}           | ${true}              | ${[DiscountClass.Product, DiscountClass.Order, DiscountClass.Shipping]}
+  `(
+    'renders combination summary when three combination options are set',
+    ({
+      combinesWithProduct,
+      combinesWithOrder,
+      combinesWithShipping,
+      selectedCombinations,
+    }) => {
+      const combinations = mountWithApp(
+        <Combinations
+          combinesWith={{
+            productDiscounts: combinesWithProduct,
+            orderDiscounts: combinesWithOrder,
+            shippingDiscounts: combinesWithShipping,
+          }}
+        />,
+      );
+
+      expect(combinations).toContainReactText(
+        `Combines with ${selectedCombinations[0].toLowerCase()}, ${selectedCombinations[1].toLowerCase()}, and ${selectedCombinations[2].toLowerCase()} discounts`,
+      );
+    },
+  );
 });


### PR DESCRIPTION
The current `SummaryCard.Combinations` component does not take into account 3 combinations being selected, which results in an empty string being returned:

![CleanShot 2023-08-09 at 13 28 53](https://github.com/Shopify/discount-app-components/assets/1695350/2d293f6d-520f-4a3d-b407-08c8d069ebd8)
