### PR TITLE
feat: [ActiveDatesCard] update tests and move away from LegacyCard

### DIFF
--- a/src/components/ActiveDatesCard/ActiveDatesCard.tsx
+++ b/src/components/ActiveDatesCard/ActiveDatesCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {LegacyCard as Card, Checkbox, FormLayout} from '@shopify/polaris';
+import {Text, Card, Checkbox, FormLayout} from '@shopify/polaris';
 import {isSameDay} from '@shopify/dates';
 import {useI18n} from '@shopify/react-i18n';
 
@@ -114,11 +114,11 @@ export function ActiveDatesCard({
   );
 
   return (
-    <Card
-      title={i18n.translate('DiscountAppComponents.ActiveDatesCard.title')}
-      sectioned
-    >
+    <Card>
       <FormLayout>
+        <Text variant="headingMd" as="h2">
+          {i18n.translate('DiscountAppComponents.ActiveDatesCard.title')}
+        </Text>
         <FormLayout.Group>
           <DatePicker
             date={{

--- a/src/components/ActiveDatesCard/tests/ActiveDatesCard.test.tsx
+++ b/src/components/ActiveDatesCard/tests/ActiveDatesCard.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import {clock} from '@shopify/jest-dom-mocks';
+import {clock, matchMedia} from '@shopify/jest-dom-mocks';
 import {mockField, mountWithApp} from 'tests/utilities';
-import {LegacyCard as Card, Checkbox, FormLayout} from '@shopify/polaris';
+import {Checkbox, FormLayout, Text} from '@shopify/polaris';
 import _ from 'lodash';
 
 import {ActiveDatesCard} from '../ActiveDatesCard';
@@ -20,6 +20,7 @@ describe('<ActiveDatesCard />', () => {
   };
 
   beforeEach(() => {
+    matchMedia.mock();
     jest.resetAllMocks();
   });
 
@@ -27,14 +28,16 @@ describe('<ActiveDatesCard />', () => {
     if (clock.isMocked()) {
       clock.restore();
     }
+    if (matchMedia.isMocked()) {
+      matchMedia.restore();
+    }
   });
 
   it('renders a Card', () => {
     const activeDates = mountWithApp(<ActiveDatesCard {...mockProps} />);
 
-    expect(activeDates).toContainReactComponent(Card, {
-      title: 'Active dates',
-      sectioned: true,
+    expect(activeDates).toContainReactComponent(Text, {
+      children: 'Active dates',
     });
   });
 


### PR DESCRIPTION
This is a part of #67 

Initially, I wanted to move to Alpha components, but they are not available anymore and regular components are the target. 
I don't know about the heading placement but the component looks like it does on the main branch. Adding an additional `FormLayout.Group` adds too many unnecessary wrappers around that heading.

New card uses matchMedia method, which requires some updates to the test file