### PR TITLE
Mock dates update

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "@shopify/react-hooks": "^3.0.5",
     "@shopify/react-i18n": "^7.8.0",
     "d3-time-format": "2.1.1",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "mockdate": "^3.0.5"
   },
   "peerDependencies": {
     "@shopify/app-bridge": "^3.7.7",

--- a/package.json
+++ b/package.json
@@ -65,8 +65,7 @@
     "@shopify/react-hooks": "^3.0.5",
     "@shopify/react-i18n": "^7.8.0",
     "d3-time-format": "2.1.1",
-    "lodash": "^4.17.21",
-    "mockdate": "^3.0.5"
+    "lodash": "^4.17.21"
   },
   "peerDependencies": {
     "@shopify/app-bridge": "^3.7.7",
@@ -121,6 +120,7 @@
     "eslint": "^8.3.0",
     "glob": "^10.3.3",
     "jest-location-mock": "^1.0.9",
+    "mockdate": "^3.0.5",
     "node-cmd": "^3.0.0",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.3.1",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@shopify/babel-preset": "^24.1.2",
     "@shopify/browserslist-config": "^3.0.0",
     "@shopify/eslint-plugin": "^41.2.0",
-    "@shopify/jest-dom-mocks": "^3.0.5",
+    "@shopify/jest-dom-mocks": "^5.0.0",
     "@shopify/loom": "^1.0.0",
     "@shopify/loom-cli": "^1.1.0",
     "@shopify/loom-plugin-build-library": "^1.0.0",

--- a/src/components/ActiveDatesCard/ActiveDatesCard.tsx
+++ b/src/components/ActiveDatesCard/ActiveDatesCard.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import {LegacyCard as Card, Checkbox, FormLayout} from '@shopify/polaris';
+import {
+  Card,
+  Checkbox,
+  FormLayout,
+  VerticalStack,
+  Text,
+} from '@shopify/polaris';
 import {isSameDay} from '@shopify/dates';
 import {useI18n} from '@shopify/react-i18n';
 
@@ -54,7 +60,6 @@ export function ActiveDatesCard({
 }: ActiveDatesCardProps) {
   const [i18n] = useI18n();
   const nowInUTC = new Date();
-
   const ianaTimezone = i18n.defaultTimezone!;
   const showEndDate = Boolean(endDate.value);
 
@@ -114,84 +119,86 @@ export function ActiveDatesCard({
   );
 
   return (
-    <Card
-      title={i18n.translate('DiscountAppComponents.ActiveDatesCard.title')}
-      sectioned
-    >
-      <FormLayout>
-        <FormLayout.Group>
-          <DatePicker
-            date={{
-              ...startDate,
-              onChange: handleStartDateTimeChange,
-            }}
-            weekStartsOn={weekStartsOn}
-            disabled={disabled}
-            label={i18n.translate(
-              'DiscountAppComponents.ActiveDatesCard.startDate',
-            )}
-            disableDatesBefore={nowInUTC.toISOString()}
-          />
-          <TimePicker
-            time={{
-              ...startDate,
-              onChange: handleStartDateTimeChange,
-            }}
-            disabled={disabled}
-            label={i18n.translate(
-              'DiscountAppComponents.ActiveDatesCard.startTime',
-              {
-                timezoneAbbreviation,
-              },
-            )}
-            disableTimesBefore={nowInUTC.toISOString()}
-          />
-        </FormLayout.Group>
-
-        <FormLayout.Group>
-          <Checkbox
-            label={i18n.translate(
-              'DiscountAppComponents.ActiveDatesCard.setEndDate',
-            )}
-            checked={showEndDate}
-            disabled={disabled}
-            onChange={handleShowEndDateChange}
-          />
-        </FormLayout.Group>
-
-        {showEndDate && endDate.value && (
+    <Card>
+      <VerticalStack gap="4">
+        <Text variant="headingMd" as="h2">
+          {i18n.translate('DiscountAppComponents.ActiveDatesCard.title')}
+        </Text>
+        <FormLayout>
           <FormLayout.Group>
             <DatePicker
               date={{
-                ...(endDate as Field<string>),
-                onChange: handleEndDateTimeChange,
-                error: endDateIsStartDate ? undefined : endDate.error,
+                ...startDate,
+                onChange: handleStartDateTimeChange,
               }}
               weekStartsOn={weekStartsOn}
               disabled={disabled}
               label={i18n.translate(
-                'DiscountAppComponents.ActiveDatesCard.endDate',
+                'DiscountAppComponents.ActiveDatesCard.startDate',
               )}
-              disableDatesBefore={disableEndDatesBefore.toISOString()}
+              disableDatesBefore={nowInUTC.toISOString()}
             />
             <TimePicker
               time={{
-                ...(endDate as Field<string>),
-                onChange: handleEndDateTimeChange,
-                error: endDateIsStartDate ? endDate.error : undefined,
+                ...startDate,
+                onChange: handleStartDateTimeChange,
               }}
               disabled={disabled}
               label={i18n.translate(
-                'DiscountAppComponents.ActiveDatesCard.endTime',
+                'DiscountAppComponents.ActiveDatesCard.startTime',
                 {
                   timezoneAbbreviation,
                 },
               )}
-              disableTimesBefore={disableEndDatesBefore.toISOString()}
+              disableTimesBefore={nowInUTC.toISOString()}
             />
           </FormLayout.Group>
-        )}
-      </FormLayout>
+
+          <FormLayout.Group>
+            <Checkbox
+              label={i18n.translate(
+                'DiscountAppComponents.ActiveDatesCard.setEndDate',
+              )}
+              checked={showEndDate}
+              disabled={disabled}
+              onChange={handleShowEndDateChange}
+            />
+          </FormLayout.Group>
+
+          {showEndDate && endDate.value && (
+            <FormLayout.Group>
+              <DatePicker
+                date={{
+                  ...(endDate as Field<string>),
+                  onChange: handleEndDateTimeChange,
+                  error: endDateIsStartDate ? undefined : endDate.error,
+                }}
+                weekStartsOn={weekStartsOn}
+                disabled={disabled}
+                label={i18n.translate(
+                  'DiscountAppComponents.ActiveDatesCard.endDate',
+                )}
+                disableDatesBefore={disableEndDatesBefore.toISOString()}
+              />
+              <TimePicker
+                time={{
+                  ...(endDate as Field<string>),
+                  onChange: handleEndDateTimeChange,
+                  error: endDateIsStartDate ? endDate.error : undefined,
+                }}
+                disabled={disabled}
+                label={i18n.translate(
+                  'DiscountAppComponents.ActiveDatesCard.endTime',
+                  {
+                    timezoneAbbreviation,
+                  },
+                )}
+                disableTimesBefore={disableEndDatesBefore.toISOString()}
+              />
+            </FormLayout.Group>
+          )}
+        </FormLayout>
+      </VerticalStack>
     </Card>
   );
 }

--- a/src/components/ActiveDatesCard/ActiveDatesCard.tsx
+++ b/src/components/ActiveDatesCard/ActiveDatesCard.tsx
@@ -1,11 +1,5 @@
 import React from 'react';
-import {
-  Card,
-  Checkbox,
-  FormLayout,
-  VerticalStack,
-  Text,
-} from '@shopify/polaris';
+import {LegacyCard as Card, Checkbox, FormLayout} from '@shopify/polaris';
 import {isSameDay} from '@shopify/dates';
 import {useI18n} from '@shopify/react-i18n';
 
@@ -60,6 +54,7 @@ export function ActiveDatesCard({
 }: ActiveDatesCardProps) {
   const [i18n] = useI18n();
   const nowInUTC = new Date();
+
   const ianaTimezone = i18n.defaultTimezone!;
   const showEndDate = Boolean(endDate.value);
 
@@ -119,86 +114,84 @@ export function ActiveDatesCard({
   );
 
   return (
-    <Card>
-      <VerticalStack gap="4">
-        <Text variant="headingMd" as="h2">
-          {i18n.translate('DiscountAppComponents.ActiveDatesCard.title')}
-        </Text>
-        <FormLayout>
+    <Card
+      title={i18n.translate('DiscountAppComponents.ActiveDatesCard.title')}
+      sectioned
+    >
+      <FormLayout>
+        <FormLayout.Group>
+          <DatePicker
+            date={{
+              ...startDate,
+              onChange: handleStartDateTimeChange,
+            }}
+            weekStartsOn={weekStartsOn}
+            disabled={disabled}
+            label={i18n.translate(
+              'DiscountAppComponents.ActiveDatesCard.startDate',
+            )}
+            disableDatesBefore={nowInUTC.toISOString()}
+          />
+          <TimePicker
+            time={{
+              ...startDate,
+              onChange: handleStartDateTimeChange,
+            }}
+            disabled={disabled}
+            label={i18n.translate(
+              'DiscountAppComponents.ActiveDatesCard.startTime',
+              {
+                timezoneAbbreviation,
+              },
+            )}
+            disableTimesBefore={nowInUTC.toISOString()}
+          />
+        </FormLayout.Group>
+
+        <FormLayout.Group>
+          <Checkbox
+            label={i18n.translate(
+              'DiscountAppComponents.ActiveDatesCard.setEndDate',
+            )}
+            checked={showEndDate}
+            disabled={disabled}
+            onChange={handleShowEndDateChange}
+          />
+        </FormLayout.Group>
+
+        {showEndDate && endDate.value && (
           <FormLayout.Group>
             <DatePicker
               date={{
-                ...startDate,
-                onChange: handleStartDateTimeChange,
+                ...(endDate as Field<string>),
+                onChange: handleEndDateTimeChange,
+                error: endDateIsStartDate ? undefined : endDate.error,
               }}
               weekStartsOn={weekStartsOn}
               disabled={disabled}
               label={i18n.translate(
-                'DiscountAppComponents.ActiveDatesCard.startDate',
+                'DiscountAppComponents.ActiveDatesCard.endDate',
               )}
-              disableDatesBefore={nowInUTC.toISOString()}
+              disableDatesBefore={disableEndDatesBefore.toISOString()}
             />
             <TimePicker
               time={{
-                ...startDate,
-                onChange: handleStartDateTimeChange,
+                ...(endDate as Field<string>),
+                onChange: handleEndDateTimeChange,
+                error: endDateIsStartDate ? endDate.error : undefined,
               }}
               disabled={disabled}
               label={i18n.translate(
-                'DiscountAppComponents.ActiveDatesCard.startTime',
+                'DiscountAppComponents.ActiveDatesCard.endTime',
                 {
                   timezoneAbbreviation,
                 },
               )}
-              disableTimesBefore={nowInUTC.toISOString()}
+              disableTimesBefore={disableEndDatesBefore.toISOString()}
             />
           </FormLayout.Group>
-
-          <FormLayout.Group>
-            <Checkbox
-              label={i18n.translate(
-                'DiscountAppComponents.ActiveDatesCard.setEndDate',
-              )}
-              checked={showEndDate}
-              disabled={disabled}
-              onChange={handleShowEndDateChange}
-            />
-          </FormLayout.Group>
-
-          {showEndDate && endDate.value && (
-            <FormLayout.Group>
-              <DatePicker
-                date={{
-                  ...(endDate as Field<string>),
-                  onChange: handleEndDateTimeChange,
-                  error: endDateIsStartDate ? undefined : endDate.error,
-                }}
-                weekStartsOn={weekStartsOn}
-                disabled={disabled}
-                label={i18n.translate(
-                  'DiscountAppComponents.ActiveDatesCard.endDate',
-                )}
-                disableDatesBefore={disableEndDatesBefore.toISOString()}
-              />
-              <TimePicker
-                time={{
-                  ...(endDate as Field<string>),
-                  onChange: handleEndDateTimeChange,
-                  error: endDateIsStartDate ? endDate.error : undefined,
-                }}
-                disabled={disabled}
-                label={i18n.translate(
-                  'DiscountAppComponents.ActiveDatesCard.endTime',
-                  {
-                    timezoneAbbreviation,
-                  },
-                )}
-                disableTimesBefore={disableEndDatesBefore.toISOString()}
-              />
-            </FormLayout.Group>
-          )}
-        </FormLayout>
-      </VerticalStack>
+        )}
+      </FormLayout>
     </Card>
   );
 }

--- a/src/components/ActiveDatesCard/tests/ActiveDatesCard.test.tsx
+++ b/src/components/ActiveDatesCard/tests/ActiveDatesCard.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {clock} from '@shopify/jest-dom-mocks';
 import {mockField, mountWithApp} from 'tests/utilities';
-import {LegacyCard as Card, Checkbox, FormLayout} from '@shopify/polaris';
+import {Card, Checkbox, FormLayout, Text} from '@shopify/polaris';
 import _ from 'lodash';
 
 import {ActiveDatesCard} from '../ActiveDatesCard';
@@ -32,9 +32,9 @@ describe('<ActiveDatesCard />', () => {
   it('renders a Card', () => {
     const activeDates = mountWithApp(<ActiveDatesCard {...mockProps} />);
 
-    expect(activeDates).toContainReactComponent(Card, {
-      title: 'Active dates',
-      sectioned: true,
+    expect(activeDates).toContainReactComponent(Card);
+    expect(activeDates).toContainReactComponent(Text, {
+      children: 'Active dates',
     });
   });
 

--- a/src/components/ActiveDatesCard/tests/ActiveDatesCard.test.tsx
+++ b/src/components/ActiveDatesCard/tests/ActiveDatesCard.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {mockField, mountWithApp} from 'tests/utilities';
-import {Card, Checkbox, FormLayout, Text} from '@shopify/polaris';
+import {LegacyCard as Card, Checkbox, FormLayout} from '@shopify/polaris';
 import _ from 'lodash';
 import MockDate from 'mockdate';
 
@@ -26,9 +26,9 @@ describe('<ActiveDatesCard />', () => {
   it('renders a Card', () => {
     const activeDates = mountWithApp(<ActiveDatesCard {...mockProps} />);
 
-    expect(activeDates).toContainReactComponent(Card);
-    expect(activeDates).toContainReactComponent(Text, {
-      children: 'Active dates',
+    expect(activeDates).toContainReactComponent(Card, {
+      title: 'Active dates',
+      sectioned: true,
     });
   });
 

--- a/src/components/ActiveDatesCard/tests/ActiveDatesCard.test.tsx
+++ b/src/components/ActiveDatesCard/tests/ActiveDatesCard.test.tsx
@@ -3,6 +3,7 @@ import {mockField, mountWithApp} from 'tests/utilities';
 import {Card, Checkbox, FormLayout, Text} from '@shopify/polaris';
 import _ from 'lodash';
 import MockDate from 'mockdate';
+
 import {ActiveDatesCard} from '../ActiveDatesCard';
 import {DatePicker} from '../../DatePicker';
 import {TimePicker} from '../../TimePicker';
@@ -21,8 +22,6 @@ describe('<ActiveDatesCard />', () => {
   beforeEach(() => {
     jest.resetAllMocks();
   });
-
-  afterEach(() => {});
 
   it('renders a Card', () => {
     const activeDates = mountWithApp(<ActiveDatesCard {...mockProps} />);

--- a/src/components/ActiveDatesCard/tests/ActiveDatesCard.test.tsx
+++ b/src/components/ActiveDatesCard/tests/ActiveDatesCard.test.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import {clock} from '@shopify/jest-dom-mocks';
 import {mockField, mountWithApp} from 'tests/utilities';
 import {Card, Checkbox, FormLayout, Text} from '@shopify/polaris';
 import _ from 'lodash';
-
+import MockDate from 'mockdate';
 import {ActiveDatesCard} from '../ActiveDatesCard';
 import {DatePicker} from '../../DatePicker';
 import {TimePicker} from '../../TimePicker';
@@ -23,11 +22,7 @@ describe('<ActiveDatesCard />', () => {
     jest.resetAllMocks();
   });
 
-  afterEach(() => {
-    if (clock.isMocked()) {
-      clock.restore();
-    }
-  });
+  afterEach(() => {});
 
   it('renders a Card', () => {
     const activeDates = mountWithApp(<ActiveDatesCard {...mockProps} />);
@@ -77,7 +72,7 @@ describe('<ActiveDatesCard />', () => {
 
     it("prevents user from selecting a start date before the current shop's date", () => {
       const now = new Date('2022-04-15T00:00:00.000Z');
-      clock.mock(now);
+      MockDate.set(now);
 
       const activeDates = mountWithApp(<ActiveDatesCard {...mockProps} />);
 
@@ -259,7 +254,7 @@ describe('<ActiveDatesCard />', () => {
 
     it("prevents user from selecting an end datetime before the start date in shop's timezone when startDate is after now", () => {
       const now = new Date('2022-04-15T00:00:00.000Z');
-      clock.mock(now);
+      MockDate.set(now);
 
       const start = '2022-05-15T00:00:00.000Z';
       const activeDates = mountWithApp(
@@ -286,7 +281,7 @@ describe('<ActiveDatesCard />', () => {
     it("prevents user from selecting an end datetime before now in shop's timezone when startDate is before now", () => {
       const now = new Date('2022-04-15T00:00:00.000Z');
       const start = '2022-03-15T00:00:00.000Z';
-      clock.mock(now);
+      MockDate.set(now);
 
       const activeDates = mountWithApp(
         <ActiveDatesCard

--- a/src/components/SummaryCard/components/ActiveDates/tests/ActiveDates.test.tsx
+++ b/src/components/SummaryCard/components/ActiveDates/tests/ActiveDates.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {clock} from '@shopify/jest-dom-mocks';
+import MockDate from 'mockdate';
 import {mountWithApp} from 'tests/utilities';
 
 import {ActiveDates} from '../ActiveDates';
@@ -14,11 +14,7 @@ describe('<ActiveDates />', () => {
   }
 
   beforeEach(() => {
-    clock.mock(todayInShopTimeZone);
-  });
-
-  afterEach(() => {
-    clock.restore();
+    MockDate.set(todayInShopTimeZone);
   });
 
   const mockProps = {

--- a/tests/setup/tests.ts
+++ b/tests/setup/tests.ts
@@ -2,8 +2,15 @@ import {destroyAll} from '@shopify/react-testing';
 import '@shopify/react-testing/matchers';
 import './matchers';
 import 'jest-location-mock';
+import {matchMedia} from '@shopify/jest-dom-mocks';
 
 // eslint-disable-next-line jest/require-top-level-describe
 afterEach(() => {
   destroyAll();
+  matchMedia.restore();
+});
+
+// eslint-disable-next-line jest/require-top-level-describe
+beforeEach(() => {
+  matchMedia.mock();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2314,10 +2314,10 @@
     base64url "^3.0.1"
     web-vitals "^3.0.1"
 
-"@shopify/async@^3.1.5":
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/@shopify/async/-/async-3.1.5.tgz#fcb1253ed2f41f22f9ce2ca28dc667003f4a1a71"
-  integrity sha512-kc/QSwQpcG2Enm6QqLUvCSbPuEabX34DTo/NKQh5eT6ud6gOCwTL3jdIiybK9RzRe3gbEUJ9cfCuggT87bXcZg==
+"@shopify/async@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@shopify/async/-/async-4.0.3.tgz#c858df7aa6c42e79138d826d01f30b14ddf1a33b"
+  integrity sha512-zg5IjXnOCAPJuhoaPKIwu9MNvAdNT/vTShOqyw65vLj+Mzdaw71Em23l+hR3IN7BPERnXywIUyQc4CEV857SFg==
 
 "@shopify/babel-preset@^24.1.2", "@shopify/babel-preset@^24.1.4":
   version "24.1.5"
@@ -2394,16 +2394,14 @@
   resolved "https://registry.yarnpkg.com/@shopify/i18n/-/i18n-2.0.1.tgz#96d73ecb599ad8c2517a7f278639984f58e9a484"
   integrity sha512-jssYom4LsUGx94D1ANzxWxKdJWcRj6YLBF9+7g0HXHE/IdCMbUlTOYWbe1MK4b1hoBipuLb/537XV4+J8af8dw==
 
-"@shopify/jest-dom-mocks@^3.0.5":
-  version "3.0.16"
-  resolved "https://registry.yarnpkg.com/@shopify/jest-dom-mocks/-/jest-dom-mocks-3.0.16.tgz#9894738336167dac56d261a99daab04e253fe69d"
-  integrity sha512-v4B8yXHuseNxERMUzTYb+f2r2WAKQwCIcAFFpk7/4sIjVy24vmhvkVw5wTvt2QSZre/5p3aSJ7RGq/gRmBvlUQ==
+"@shopify/jest-dom-mocks@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@shopify/jest-dom-mocks/-/jest-dom-mocks-5.0.0.tgz#e84e3a4cdd849914ed3638d417c76ebacf585219"
+  integrity sha512-Ol/DJZqCZhzUI2hYZILwHTwcLNaqlTs+pxnkEPkVLvyQt0jXkGPen6z7Xm7B5QKJTKy2Qrerx0ECSQmhqSuAUA==
   dependencies:
-    "@shopify/async" "^3.1.5"
+    "@shopify/async" "^4.0.3"
     "@types/fetch-mock" "^7.3.3"
-    "@types/lolex" "^2.1.3"
     fetch-mock "^9.11.0"
-    lolex "^2.7.5"
     promise "^8.0.3"
 
 "@shopify/loom-cli@^1.1.0":
@@ -3530,11 +3528,6 @@
   version "4.14.195"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.195.tgz#bafc975b252eb6cea78882ce8a7b6bf22a6de632"
   integrity sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==
-
-"@types/lolex@^2.1.3":
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@types/lolex/-/lolex-2.1.3.tgz#793557c9b8ad319b4c8e4c6548b90893f4aa5f69"
-  integrity sha512-nEipOLYyZJ4RKHCg7tlR37ewFy91oggmip2MBzPdVQ8QhTFqjcRhE8R0t4tfpDnSlxGWHoEGJl0UCC4kYhqoiw==
 
 "@types/mdast@^3.0.0":
   version "3.0.12"
@@ -10050,11 +10043,6 @@ lodash@4.17.21, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
-lolex@^2.7.5:
-  version "2.7.5"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.5.tgz#113001d56bfc7e02d56e36291cc5c413d1aa0733"
-  integrity sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==
 
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10587,6 +10587,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+mockdate@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.5.tgz#789be686deb3149e7df2b663d2bc4392bc3284fb"
+  integrity sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
### Descritpion

- Upgrading jest-dom-mocks where `clock` is deprecated.
- Added mockdate package to help with dates mocks
- Updated tests where clock was used to use mockdate