### PR TITLE
refactor: use alpha components

### DIFF
--- a/.changeset/nervous-eagles-clean.md
+++ b/.changeset/nervous-eagles-clean.md
@@ -2,4 +2,4 @@
 '@shopify/discount-app-components': patch
 ---
 
-Upgrade CombinationCard to use Alpha components
+Upgrade CombinationCard, HelpText, CountriesAndRatesCard to use Alpha components

--- a/.changeset/nervous-eagles-clean.md
+++ b/.changeset/nervous-eagles-clean.md
@@ -2,4 +2,4 @@
 '@shopify/discount-app-components': patch
 ---
 
-Upgrade CombinationCard, HelpText, CountriesAndRatesCard, CurrencyField, CustomerEligibilityCard to use Alpha components
+Upgrade CombinationCard, HelpText, CountriesAndRatesCard, CurrencyField, CustomerEligibilityCard, MethodCard, MinimumRequirementsCard, MinimumRequirementsCard, PurchaseTypeCard, Header, Performance, UsageLimitsCard, RecuringPayment, SummaryCard to use Alpha components

--- a/.changeset/nervous-eagles-clean.md
+++ b/.changeset/nervous-eagles-clean.md
@@ -2,4 +2,4 @@
 '@shopify/discount-app-components': patch
 ---
 
-Upgrade CombinationCard, HelpText, CountriesAndRatesCard, CurrencyField to use Alpha components
+Upgrade CombinationCard, HelpText, CountriesAndRatesCard, CurrencyField, CustomerEligibilityCard to use Alpha components

--- a/.changeset/nervous-eagles-clean.md
+++ b/.changeset/nervous-eagles-clean.md
@@ -2,4 +2,4 @@
 '@shopify/discount-app-components': patch
 ---
 
-Upgrade CombinationCard, HelpText, CountriesAndRatesCard to use Alpha components
+Upgrade CombinationCard, HelpText, CountriesAndRatesCard, CurrencyField to use Alpha components

--- a/.changeset/nervous-eagles-clean.md
+++ b/.changeset/nervous-eagles-clean.md
@@ -2,4 +2,4 @@
 '@shopify/discount-app-components': patch
 ---
 
-Upgrade CombinationCard, HelpText, CountriesAndRatesCard, CurrencyField, CustomerEligibilityCard, MethodCard, MinimumRequirementsCard, MinimumRequirementsCard, PurchaseTypeCard, Header, Performance, UsageLimitsCard, RecuringPayment, SummaryCard to use Alpha components
+Upgrade CombinationCard, HelpText, CountriesAndRatesCard, CurrencyField, CustomerEligibilityCard, MethodCard, MinimumRequirementsCard, PurchaseTypeCard, Header, Performance, UsageLimitsCard, RecuringPayment, SummaryCard to use Alpha components

--- a/.changeset/nervous-eagles-clean.md
+++ b/.changeset/nervous-eagles-clean.md
@@ -1,0 +1,5 @@
+---
+'@shopify/discount-app-components': patch
+---
+
+Upgrade CombinationCard to use Alpha components

--- a/src/components/ActiveDatesCard/ActiveDatesCard.tsx
+++ b/src/components/ActiveDatesCard/ActiveDatesCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Text, Card, Checkbox, FormLayout} from '@shopify/polaris';
+import {Text, Card, Checkbox, FormLayout, Box} from '@shopify/polaris';
 import {isSameDay} from '@shopify/dates';
 import {useI18n} from '@shopify/react-i18n';
 
@@ -114,85 +114,87 @@ export function ActiveDatesCard({
   );
 
   return (
-    <Card>
-      <FormLayout>
-        <Text variant="headingMd" as="h2">
-          {i18n.translate('DiscountAppComponents.ActiveDatesCard.title')}
-        </Text>
-        <FormLayout.Group>
-          <DatePicker
-            date={{
-              ...startDate,
-              onChange: handleStartDateTimeChange,
-            }}
-            weekStartsOn={weekStartsOn}
-            disabled={disabled}
-            label={i18n.translate(
-              'DiscountAppComponents.ActiveDatesCard.startDate',
-            )}
-            disableDatesBefore={nowInUTC.toISOString()}
-          />
-          <TimePicker
-            time={{
-              ...startDate,
-              onChange: handleStartDateTimeChange,
-            }}
-            disabled={disabled}
-            label={i18n.translate(
-              'DiscountAppComponents.ActiveDatesCard.startTime',
-              {
-                timezoneAbbreviation,
-              },
-            )}
-            disableTimesBefore={nowInUTC.toISOString()}
-          />
-        </FormLayout.Group>
-
-        <FormLayout.Group>
-          <Checkbox
-            label={i18n.translate(
-              'DiscountAppComponents.ActiveDatesCard.setEndDate',
-            )}
-            checked={showEndDate}
-            disabled={disabled}
-            onChange={handleShowEndDateChange}
-          />
-        </FormLayout.Group>
-
-        {showEndDate && endDate.value && (
+    <Box paddingBlockEnd="4">
+      <Card padding="4">
+        <FormLayout>
+          <Text variant="headingMd" as="h2">
+            {i18n.translate('DiscountAppComponents.ActiveDatesCard.title')}
+          </Text>
           <FormLayout.Group>
             <DatePicker
               date={{
-                ...(endDate as Field<string>),
-                onChange: handleEndDateTimeChange,
-                error: endDateIsStartDate ? undefined : endDate.error,
+                ...startDate,
+                onChange: handleStartDateTimeChange,
               }}
               weekStartsOn={weekStartsOn}
               disabled={disabled}
               label={i18n.translate(
-                'DiscountAppComponents.ActiveDatesCard.endDate',
+                'DiscountAppComponents.ActiveDatesCard.startDate',
               )}
-              disableDatesBefore={disableEndDatesBefore.toISOString()}
+              disableDatesBefore={nowInUTC.toISOString()}
             />
             <TimePicker
               time={{
-                ...(endDate as Field<string>),
-                onChange: handleEndDateTimeChange,
-                error: endDateIsStartDate ? endDate.error : undefined,
+                ...startDate,
+                onChange: handleStartDateTimeChange,
               }}
               disabled={disabled}
               label={i18n.translate(
-                'DiscountAppComponents.ActiveDatesCard.endTime',
+                'DiscountAppComponents.ActiveDatesCard.startTime',
                 {
                   timezoneAbbreviation,
                 },
               )}
-              disableTimesBefore={disableEndDatesBefore.toISOString()}
+              disableTimesBefore={nowInUTC.toISOString()}
             />
           </FormLayout.Group>
-        )}
-      </FormLayout>
-    </Card>
+
+          <FormLayout.Group>
+            <Checkbox
+              label={i18n.translate(
+                'DiscountAppComponents.ActiveDatesCard.setEndDate',
+              )}
+              checked={showEndDate}
+              disabled={disabled}
+              onChange={handleShowEndDateChange}
+            />
+          </FormLayout.Group>
+
+          {showEndDate && endDate.value && (
+            <FormLayout.Group>
+              <DatePicker
+                date={{
+                  ...(endDate as Field<string>),
+                  onChange: handleEndDateTimeChange,
+                  error: endDateIsStartDate ? undefined : endDate.error,
+                }}
+                weekStartsOn={weekStartsOn}
+                disabled={disabled}
+                label={i18n.translate(
+                  'DiscountAppComponents.ActiveDatesCard.endDate',
+                )}
+                disableDatesBefore={disableEndDatesBefore.toISOString()}
+              />
+              <TimePicker
+                time={{
+                  ...(endDate as Field<string>),
+                  onChange: handleEndDateTimeChange,
+                  error: endDateIsStartDate ? endDate.error : undefined,
+                }}
+                disabled={disabled}
+                label={i18n.translate(
+                  'DiscountAppComponents.ActiveDatesCard.endTime',
+                  {
+                    timezoneAbbreviation,
+                  },
+                )}
+                disableTimesBefore={disableEndDatesBefore.toISOString()}
+              />
+            </FormLayout.Group>
+          )}
+        </FormLayout>
+      </Card>
+    </Box>
   );
 }
 

--- a/src/components/CombinationCard/CombinationCard.tsx
+++ b/src/components/CombinationCard/CombinationCard.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import {
   Banner,
   Link,
-  LegacyCard as Card,
+  Card,
   ChoiceList,
-  LegacyStack as Stack,
+  VerticalStack,
   Text,
   ChoiceListProps,
 } from '@shopify/polaris';
@@ -79,8 +79,11 @@ export function CombinationCard({
       selectedChoices.includes(DiscountClass.Order));
 
   return (
-    <Card title={i18n.translate('title', I18N_SCOPE)} sectioned>
-      <Stack vertical spacing="baseTight">
+    <Card>
+      <Text variant="headingMd" as="h2">
+        {i18n.translate('title', I18N_SCOPE)}
+      </Text>
+      <VerticalStack>
         {shouldShowBanner && (
           <Banner
             title={i18n.translate('warning.title', I18N_SCOPE)}
@@ -90,7 +93,7 @@ export function CombinationCard({
               {i18n.translate('warning.description', I18N_SCOPE)}{' '}
               <Link
                 url={`https://help.shopify.com/${i18n.locale}/manual/discounts/combining-discounts`}
-                external
+                target="_blank"
               >
                 {i18n.translate('warning.link', I18N_SCOPE)}
               </Link>
@@ -128,7 +131,7 @@ export function CombinationCard({
           selected={getSelectedChoices(combinableDiscountTypes.value)}
           onChange={handleDiscountCombinesWithChange}
         />
-      </Stack>
+      </VerticalStack>
     </Card>
   );
 }

--- a/src/components/CombinationCard/CombinationCard.tsx
+++ b/src/components/CombinationCard/CombinationCard.tsx
@@ -80,10 +80,10 @@ export function CombinationCard({
 
   return (
     <Card>
-      <Text variant="headingMd" as="h2">
-        {i18n.translate('title', I18N_SCOPE)}
-      </Text>
-      <VerticalStack>
+      <VerticalStack gap="4">
+        <Text variant="headingMd" as="h2">
+          {i18n.translate('title', I18N_SCOPE)}
+        </Text>
         {shouldShowBanner && (
           <Banner
             title={i18n.translate('warning.title', I18N_SCOPE)}

--- a/src/components/CombinationCard/CombinationCard.tsx
+++ b/src/components/CombinationCard/CombinationCard.tsx
@@ -7,6 +7,7 @@ import {
   VerticalStack,
   Text,
   ChoiceListProps,
+  Box,
 } from '@shopify/polaris';
 import {I18n, useI18n} from '@shopify/react-i18n';
 
@@ -79,60 +80,62 @@ export function CombinationCard({
       selectedChoices.includes(DiscountClass.Order));
 
   return (
-    <Card>
-      <VerticalStack gap="4">
-        <Text variant="headingMd" as="h2">
-          {i18n.translate('title', I18N_SCOPE)}
-        </Text>
-        {shouldShowBanner && (
-          <Banner
-            title={i18n.translate('warning.title', I18N_SCOPE)}
-            status="warning"
-          >
-            <p>
-              {i18n.translate('warning.description', I18N_SCOPE)}{' '}
-              <Link
-                url={`https://help.shopify.com/${i18n.locale}/manual/discounts/combining-discounts`}
-                target="_blank"
-              >
-                {i18n.translate('warning.link', I18N_SCOPE)}
-              </Link>
-            </p>
-          </Banner>
-        )}
-        <p>
-          {trimmedDescriptor ? (
-            <>
-              <Text as="span" fontWeight="semibold">
-                {trimmedDescriptor}
-              </Text>{' '}
-              {i18n.translate('discountNameFilled', I18N_SCOPE)}
-            </>
-          ) : (
-            i18n.translate('discountNameNotFilled', I18N_SCOPE, {
-              discountClass: i18n.translate(
-                `discountClass.${discountClass.toLowerCase()}`,
-                I18N_SCOPE,
-              ),
-            })
+    <Box paddingBlockEnd="4">
+      <Card padding="4">
+        <VerticalStack gap="4">
+          <Text variant="headingMd" as="h2">
+            {i18n.translate('title', I18N_SCOPE)}
+          </Text>
+          {shouldShowBanner && (
+            <Banner
+              title={i18n.translate('warning.title', I18N_SCOPE)}
+              status="warning"
+            >
+              <p>
+                {i18n.translate('warning.description', I18N_SCOPE)}{' '}
+                <Link
+                  url={`https://help.shopify.com/${i18n.locale}/manual/discounts/combining-discounts`}
+                  target="_blank"
+                >
+                  {i18n.translate('warning.link', I18N_SCOPE)}
+                </Link>
+              </p>
+            </Banner>
           )}
-        </p>
-        <ChoiceList
-          title={i18n.translate('combinesWith', I18N_SCOPE)}
-          titleHidden
-          allowMultiple
-          choices={buildChoices({
-            discountClass,
-            discountId,
-            discountDescriptor,
-            i18n,
-            combinableDiscountCounts,
-          })}
-          selected={getSelectedChoices(combinableDiscountTypes.value)}
-          onChange={handleDiscountCombinesWithChange}
-        />
-      </VerticalStack>
-    </Card>
+          <p>
+            {trimmedDescriptor ? (
+              <>
+                <Text as="span" fontWeight="semibold">
+                  {trimmedDescriptor}
+                </Text>{' '}
+                {i18n.translate('discountNameFilled', I18N_SCOPE)}
+              </>
+            ) : (
+              i18n.translate('discountNameNotFilled', I18N_SCOPE, {
+                discountClass: i18n.translate(
+                  `discountClass.${discountClass.toLowerCase()}`,
+                  I18N_SCOPE,
+                ),
+              })
+            )}
+          </p>
+          <ChoiceList
+            title={i18n.translate('combinesWith', I18N_SCOPE)}
+            titleHidden
+            allowMultiple
+            choices={buildChoices({
+              discountClass,
+              discountId,
+              discountDescriptor,
+              i18n,
+              combinableDiscountCounts,
+            })}
+            selected={getSelectedChoices(combinableDiscountTypes.value)}
+            onChange={handleDiscountCombinesWithChange}
+          />
+        </VerticalStack>
+      </Card>
+    </Box>
   );
 }
 

--- a/src/components/CombinationCard/components/HelpText/HelpText.tsx
+++ b/src/components/CombinationCard/components/HelpText/HelpText.tsx
@@ -1,5 +1,5 @@
 import React, {useRef} from 'react';
-import {Button, Text, LegacyStack as Stack, Link} from '@shopify/polaris';
+import {Button, Text, Link, VerticalStack} from '@shopify/polaris';
 import {useI18n} from '@shopify/react-i18n';
 import {useAppBridge} from '@shopify/app-bridge-react';
 import {Modal} from '@shopify/app-bridge/actions';
@@ -55,7 +55,7 @@ export function HelpText({
   };
 
   return count > 0 ? (
-    <Stack spacing="none" vertical>
+    <VerticalStack>
       <Text as="span" color="subdued">
         {i18n.translate(
           'combinations.info',
@@ -81,7 +81,7 @@ export function HelpText({
       <Text as="span" color="subdued">
         {i18n.translate('combinations.multipleEligibleDiscounts', {scope})}
       </Text>
-    </Stack>
+    </VerticalStack>
   ) : (
     <>
       <Text as="span" color="subdued">

--- a/src/components/CombinationCard/tests/CombinationCard.test.tsx
+++ b/src/components/CombinationCard/tests/CombinationCard.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Banner, LegacyCard as Card, ChoiceList} from '@shopify/polaris';
+import {Banner, Card, ChoiceList, Text} from '@shopify/polaris';
 import {mockField, mountWithApp} from 'tests/utilities';
 import {composeGid} from '@shopify/admin-graphql-api-utilities';
 
@@ -77,9 +77,9 @@ describe('<CombinationCard />', () => {
   it('renders <Card />', () => {
     const combinationCard = mountWithApp(<CombinationCard {...mockProps} />);
 
-    expect(combinationCard).toContainReactComponent(Card, {
-      sectioned: true,
-      title: 'Combinations',
+    expect(combinationCard).toContainReactComponent(Card);
+    expect(combinationCard).toContainReactComponent(Text, {
+      children: 'Combinations',
     });
   });
 

--- a/src/components/CountriesAndRatesCard/CountriesAndRatesCard.tsx
+++ b/src/components/CountriesAndRatesCard/CountriesAndRatesCard.tsx
@@ -6,6 +6,7 @@ import {
   InlineError,
   VerticalStack,
   Text,
+  Box,
 } from '@shopify/polaris';
 import {CurrencyCode, useI18n} from '@shopify/react-i18n';
 
@@ -64,96 +65,97 @@ export function CountriesAndRatesCard({
   const localizeCountry = useLocalizeCountry();
 
   return (
-    <Card>
-      <VerticalStack gap="4">
-        <Text variant="headingMd" as="h2">
-          {i18n.translate('DiscountAppComponents.CountriesAndRatesCard.title')}
-        </Text>
-        {/* <Card.Section> */}
-        <ChoiceList
-          title={i18n.translate(
-            'DiscountAppComponents.CountriesAndRatesCard.choiceList.title',
-          )}
-          titleHidden
-          choices={[
-            {
-              value: CountrySelectionType.AllCountries,
-              label: i18n.translate(
-                'DiscountAppComponents.CountriesAndRatesCard.choiceList.all',
-              ),
-            },
-            {
-              value: CountrySelectionType.SelectedCountries,
-              label: i18n.translate(
-                'DiscountAppComponents.CountriesAndRatesCard.choiceList.selected',
-              ),
-            },
-          ]}
-          selected={[countrySelectionType.value]}
-          onChange={(values: CountrySelectionType[]) =>
-            countrySelectionType.onChange(values[0])
-          }
-        />
-        {countrySelectionType.value ===
-          CountrySelectionType.SelectedCountries && (
-          <>
-            <div className={styles.countrySelectorActivator}>
-              {countrySelector}
-            </div>
-            <SelectedItemsList
-              items={selectedCountries.value.map(localizeCountry)}
-              renderItem={(item: Country) => <div>{item.name}</div>}
-              onRemoveItem={(itemId: string) =>
-                selectedCountries.onChange(
-                  selectedCountries.value.filter(
-                    (countryCode) => countryCode !== itemId,
-                  ),
-                )
-              }
-            />
-          </>
-        )}
-        {/* </Card.Section> */}
-        {/* <Card.Section */}
-        <Text variant="headingMd" as="h2">
-          {i18n.translate(
-            'DiscountAppComponents.CountriesAndRatesCard.excludeShippingRatesSection.title',
-          )}
-        </Text>
-        {/* > */}
-        <Checkbox
-          label={i18n.translate(
-            'DiscountAppComponents.CountriesAndRatesCard.excludeShippingRatesSection.checkboxLabel',
-          )}
-          checked={excludeShippingRates.value}
-          onChange={(value: boolean) => excludeShippingRates.onChange(value)}
-        />
-        {excludeShippingRates.value && (
-          <>
-            <div className={styles.ShippingRatesTextField}>
-              <CurrencyField
-                id={EXCLUDE_SHIPPING_RATES_FIELD_ID}
-                currencyCode={currencyCode}
-                error={Boolean(maximumShippingPrice.error)}
-                labelHidden
-                label={i18n.translate(
-                  'DiscountAppComponents.CountriesAndRatesCard.excludeShippingRatesSection.checkboxLabel',
-                )}
-                onChange={maximumShippingPrice.onChange}
-                value={String(maximumShippingPrice.value)}
-                positiveOnly
-              />
-            </div>
-            {maximumShippingPrice?.error && (
-              <InlineError
-                fieldID={EXCLUDE_SHIPPING_RATES_FIELD_ID}
-                message={maximumShippingPrice.error}
-              />
+    <Box paddingBlockEnd="4">
+      <Card padding="4">
+        <VerticalStack gap="4">
+          <Text variant="headingMd" as="h2">
+            {i18n.translate(
+              'DiscountAppComponents.CountriesAndRatesCard.title',
             )}
-          </>
-        )}
-        {/* </Card.Section> */}
-      </VerticalStack>
-    </Card>
+          </Text>
+          <ChoiceList
+            title={i18n.translate(
+              'DiscountAppComponents.CountriesAndRatesCard.choiceList.title',
+            )}
+            titleHidden
+            choices={[
+              {
+                value: CountrySelectionType.AllCountries,
+                label: i18n.translate(
+                  'DiscountAppComponents.CountriesAndRatesCard.choiceList.all',
+                ),
+              },
+              {
+                value: CountrySelectionType.SelectedCountries,
+                label: i18n.translate(
+                  'DiscountAppComponents.CountriesAndRatesCard.choiceList.selected',
+                ),
+              },
+            ]}
+            selected={[countrySelectionType.value]}
+            onChange={(values: CountrySelectionType[]) =>
+              countrySelectionType.onChange(values[0])
+            }
+          />
+          {countrySelectionType.value ===
+            CountrySelectionType.SelectedCountries && (
+            <>
+              <div className={styles.countrySelectorActivator}>
+                {countrySelector}
+              </div>
+              <SelectedItemsList
+                items={selectedCountries.value.map(localizeCountry)}
+                renderItem={(item: Country) => <div>{item.name}</div>}
+                onRemoveItem={(itemId: string) =>
+                  selectedCountries.onChange(
+                    selectedCountries.value.filter(
+                      (countryCode) => countryCode !== itemId,
+                    ),
+                  )
+                }
+              />
+            </>
+          )}
+          <Text variant="headingMd" as="h2">
+            {i18n.translate(
+              'DiscountAppComponents.CountriesAndRatesCard.excludeShippingRatesSection.title',
+            )}
+          </Text>
+          {/* > */}
+          <Checkbox
+            label={i18n.translate(
+              'DiscountAppComponents.CountriesAndRatesCard.excludeShippingRatesSection.checkboxLabel',
+            )}
+            checked={excludeShippingRates.value}
+            onChange={(value: boolean) => excludeShippingRates.onChange(value)}
+          />
+          {excludeShippingRates.value && (
+            <>
+              <div className={styles.ShippingRatesTextField}>
+                <CurrencyField
+                  id={EXCLUDE_SHIPPING_RATES_FIELD_ID}
+                  currencyCode={currencyCode}
+                  error={Boolean(maximumShippingPrice.error)}
+                  labelHidden
+                  label={i18n.translate(
+                    'DiscountAppComponents.CountriesAndRatesCard.excludeShippingRatesSection.checkboxLabel',
+                  )}
+                  onChange={maximumShippingPrice.onChange}
+                  value={String(maximumShippingPrice.value)}
+                  positiveOnly
+                />
+              </div>
+              {maximumShippingPrice?.error && (
+                <InlineError
+                  fieldID={EXCLUDE_SHIPPING_RATES_FIELD_ID}
+                  message={maximumShippingPrice.error}
+                />
+              )}
+            </>
+          )}
+          {/* </Card.Section> */}
+        </VerticalStack>
+      </Card>
+    </Box>
   );
 }

--- a/src/components/CountriesAndRatesCard/CountriesAndRatesCard.tsx
+++ b/src/components/CountriesAndRatesCard/CountriesAndRatesCard.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import {
-  LegacyCard as Card,
+  Card,
   ChoiceList,
   Checkbox,
   InlineError,
+  VerticalStack,
+  Text,
 } from '@shopify/polaris';
 import {CurrencyCode, useI18n} from '@shopify/react-i18n';
 
@@ -62,12 +64,12 @@ export function CountriesAndRatesCard({
   const localizeCountry = useLocalizeCountry();
 
   return (
-    <Card
-      title={i18n.translate(
-        'DiscountAppComponents.CountriesAndRatesCard.title',
-      )}
-    >
-      <Card.Section>
+    <Card>
+      <VerticalStack gap="4">
+        <Text variant="headingMd" as="h2">
+          {i18n.translate('DiscountAppComponents.CountriesAndRatesCard.title')}
+        </Text>
+        {/* <Card.Section> */}
         <ChoiceList
           title={i18n.translate(
             'DiscountAppComponents.CountriesAndRatesCard.choiceList.title',
@@ -111,12 +113,14 @@ export function CountriesAndRatesCard({
             />
           </>
         )}
-      </Card.Section>
-      <Card.Section
-        title={i18n.translate(
-          'DiscountAppComponents.CountriesAndRatesCard.excludeShippingRatesSection.title',
-        )}
-      >
+        {/* </Card.Section> */}
+        {/* <Card.Section */}
+        <Text variant="headingMd" as="h2">
+          {i18n.translate(
+            'DiscountAppComponents.CountriesAndRatesCard.excludeShippingRatesSection.title',
+          )}
+        </Text>
+        {/* > */}
         <Checkbox
           label={i18n.translate(
             'DiscountAppComponents.CountriesAndRatesCard.excludeShippingRatesSection.checkboxLabel',
@@ -148,7 +152,8 @@ export function CountriesAndRatesCard({
             )}
           </>
         )}
-      </Card.Section>
+        {/* </Card.Section> */}
+      </VerticalStack>
     </Card>
   );
 }

--- a/src/components/CountriesAndRatesCard/tests/CountriesAndRatesCard.test.tsx
+++ b/src/components/CountriesAndRatesCard/tests/CountriesAndRatesCard.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-  LegacyCard,
   ChoiceList,
   Checkbox,
   InlineError,
@@ -38,8 +37,8 @@ describe('<CountriesAndRatesCard />', () => {
       <CountriesAndRatesCard {...mockProps} />,
     );
 
-    expect(countriesAndRatesCard).toContainReactComponent(LegacyCard.Header, {
-      title: 'Countries',
+    expect(countriesAndRatesCard).toContainReactComponent(Text, {
+      children: 'Countries',
     });
     expect(countriesAndRatesCard).toContainReactComponent(ChoiceList, {
       title: 'Countries and rates',

--- a/src/components/CurrencyField/CurrencyField.tsx
+++ b/src/components/CurrencyField/CurrencyField.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {useI18n, CurrencyCode, I18n} from '@shopify/react-i18n';
-import {LegacyStack as Stack} from '@shopify/polaris';
+import {HorizontalStack, VerticalStack} from '@shopify/polaris';
 
 import {
   FormattedNumberField,
@@ -94,10 +94,10 @@ function renderSuffix(
 
   if (appendSuffixToCurrency && !prefixed && suffix) {
     return (
-      <Stack alignment="center" spacing="extraTight">
+      <HorizontalStack align="center">
         <div>{symbol}</div>
         <div>{suffix}</div>
-      </Stack>
+      </HorizontalStack>
     );
   }
 

--- a/src/components/CurrencyField/CurrencyField.tsx
+++ b/src/components/CurrencyField/CurrencyField.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {useI18n, CurrencyCode, I18n} from '@shopify/react-i18n';
-import {HorizontalStack, VerticalStack} from '@shopify/polaris';
+import {HorizontalStack} from '@shopify/polaris';
 
 import {
   FormattedNumberField,

--- a/src/components/CustomerEligibilityCard/CustomerEligibilityCard.tsx
+++ b/src/components/CustomerEligibilityCard/CustomerEligibilityCard.tsx
@@ -1,9 +1,5 @@
 import React from 'react';
-import {
-  LegacyCard as Card,
-  ChoiceList,
-  LegacyStack as Stack,
-} from '@shopify/polaris';
+import {Card, ChoiceList, Text, VerticalStack} from '@shopify/polaris';
 import {useI18n} from '@shopify/react-i18n';
 import {Action} from '@shopify/app-bridge/actions/Navigation/Redirect';
 import {parseGid} from '@shopify/admin-graphql-api-utilities';
@@ -56,47 +52,51 @@ export function CustomerEligibilityCard({
   const [i18n] = useI18n();
 
   return (
-    <Card title={i18n.translate('title', I18N_SCOPE)} sectioned>
-      <ChoiceList
-        title={i18n.translate('title', I18N_SCOPE)}
-        titleHidden
-        selected={[eligibility.value]}
-        choices={[
-          {
-            label: i18n.translate('everyone', I18N_SCOPE),
-            value: Eligibility.Everyone,
-          },
-          {
-            label: i18n.translate('customerSegments', I18N_SCOPE),
-            value: Eligibility.CustomerSegments,
-          },
-          {
-            label: i18n.translate('customers', I18N_SCOPE),
-            value: Eligibility.Customers,
-          },
-        ]}
-        onChange={(selectedEligibility: Eligibility[]) => {
-          eligibility.onChange(selectedEligibility[0]);
-        }}
-      />
+    <Card>
+      <VerticalStack gap="4">
+        <Text variant="headingMd" as="h2">
+          {i18n.translate('title', I18N_SCOPE)}
+        </Text>
+        <ChoiceList
+          title={i18n.translate('title', I18N_SCOPE)}
+          titleHidden
+          selected={[eligibility.value]}
+          choices={[
+            {
+              label: i18n.translate('everyone', I18N_SCOPE),
+              value: Eligibility.Everyone,
+            },
+            {
+              label: i18n.translate('customerSegments', I18N_SCOPE),
+              value: Eligibility.CustomerSegments,
+            },
+            {
+              label: i18n.translate('customers', I18N_SCOPE),
+              value: Eligibility.Customers,
+            },
+          ]}
+          onChange={(selectedEligibility: Eligibility[]) => {
+            eligibility.onChange(selectedEligibility[0]);
+          }}
+        />
 
-      {eligibility.value === Eligibility.CustomerSegments && (
-        <Stack vertical spacing="extraTight">
-          {customerSegmentSelector}
+        {eligibility.value === Eligibility.CustomerSegments && (
+          <VerticalStack gap="4">
+            {customerSegmentSelector}
 
-          <SelectedCustomerSegmentsList
-            selectedCustomerSegments={selectedCustomerSegments}
-          />
-        </Stack>
-      )}
+            <SelectedCustomerSegmentsList
+              selectedCustomerSegments={selectedCustomerSegments}
+            />
+          </VerticalStack>
+        )}
 
-      {eligibility.value === Eligibility.Customers && (
-        <Stack vertical spacing="extraTight">
-          {customerSelector}
-
-          <SelectedCustomersList selectedCustomers={selectedCustomers} />
-        </Stack>
-      )}
+        {eligibility.value === Eligibility.Customers && (
+          <VerticalStack gap="4">
+            {customerSelector}
+            <SelectedCustomersList selectedCustomers={selectedCustomers} />
+          </VerticalStack>
+        )}
+      </VerticalStack>
     </Card>
   );
 }

--- a/src/components/CustomerEligibilityCard/CustomerEligibilityCard.tsx
+++ b/src/components/CustomerEligibilityCard/CustomerEligibilityCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Card, ChoiceList, Text, VerticalStack} from '@shopify/polaris';
+import {Box, Card, ChoiceList, Text, VerticalStack} from '@shopify/polaris';
 import {useI18n} from '@shopify/react-i18n';
 import {Action} from '@shopify/app-bridge/actions/Navigation/Redirect';
 import {parseGid} from '@shopify/admin-graphql-api-utilities';
@@ -52,52 +52,54 @@ export function CustomerEligibilityCard({
   const [i18n] = useI18n();
 
   return (
-    <Card>
-      <VerticalStack gap="4">
-        <Text variant="headingMd" as="h2">
-          {i18n.translate('title', I18N_SCOPE)}
-        </Text>
-        <ChoiceList
-          title={i18n.translate('title', I18N_SCOPE)}
-          titleHidden
-          selected={[eligibility.value]}
-          choices={[
-            {
-              label: i18n.translate('everyone', I18N_SCOPE),
-              value: Eligibility.Everyone,
-            },
-            {
-              label: i18n.translate('customerSegments', I18N_SCOPE),
-              value: Eligibility.CustomerSegments,
-            },
-            {
-              label: i18n.translate('customers', I18N_SCOPE),
-              value: Eligibility.Customers,
-            },
-          ]}
-          onChange={(selectedEligibility: Eligibility[]) => {
-            eligibility.onChange(selectedEligibility[0]);
-          }}
-        />
+    <Box paddingBlockEnd="4">
+      <Card padding="4">
+        <VerticalStack gap="4">
+          <Text variant="headingMd" as="h2">
+            {i18n.translate('title', I18N_SCOPE)}
+          </Text>
+          <ChoiceList
+            title={i18n.translate('title', I18N_SCOPE)}
+            titleHidden
+            selected={[eligibility.value]}
+            choices={[
+              {
+                label: i18n.translate('everyone', I18N_SCOPE),
+                value: Eligibility.Everyone,
+              },
+              {
+                label: i18n.translate('customerSegments', I18N_SCOPE),
+                value: Eligibility.CustomerSegments,
+              },
+              {
+                label: i18n.translate('customers', I18N_SCOPE),
+                value: Eligibility.Customers,
+              },
+            ]}
+            onChange={(selectedEligibility: Eligibility[]) => {
+              eligibility.onChange(selectedEligibility[0]);
+            }}
+          />
 
-        {eligibility.value === Eligibility.CustomerSegments && (
-          <VerticalStack gap="4">
-            {customerSegmentSelector}
+          {eligibility.value === Eligibility.CustomerSegments && (
+            <VerticalStack gap="4">
+              {customerSegmentSelector}
 
-            <SelectedCustomerSegmentsList
-              selectedCustomerSegments={selectedCustomerSegments}
-            />
-          </VerticalStack>
-        )}
+              <SelectedCustomerSegmentsList
+                selectedCustomerSegments={selectedCustomerSegments}
+              />
+            </VerticalStack>
+          )}
 
-        {eligibility.value === Eligibility.Customers && (
-          <VerticalStack gap="4">
-            {customerSelector}
-            <SelectedCustomersList selectedCustomers={selectedCustomers} />
-          </VerticalStack>
-        )}
-      </VerticalStack>
-    </Card>
+          {eligibility.value === Eligibility.Customers && (
+            <VerticalStack gap="4">
+              {customerSelector}
+              <SelectedCustomersList selectedCustomers={selectedCustomers} />
+            </VerticalStack>
+          )}
+        </VerticalStack>
+      </Card>
+    </Box>
   );
 }
 

--- a/src/components/CustomerEligibilityCard/tests/CustomerEligibilityCard.test.tsx
+++ b/src/components/CustomerEligibilityCard/tests/CustomerEligibilityCard.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {mockField, mountWithApp} from 'tests/utilities';
 import {Action} from '@shopify/app-bridge/actions/Navigation/Redirect';
 import {composeGid, parseGid} from '@shopify/admin-graphql-api-utilities';
-import {LegacyCard as Card, ChoiceList} from '@shopify/polaris';
+import {ChoiceList, Card, Text} from '@shopify/polaris';
 
 import {
   CustomerEligibilityCard,
@@ -61,8 +61,9 @@ describe('<CustomerEligibilityCard />', () => {
       <CustomerEligibilityCard {...mockProps} />,
     );
 
-    expect(customerEligibilityCard).toContainReactComponent(Card, {
-      title: 'Customer eligibility',
+    expect(customerEligibilityCard).toContainReactComponent(Card);
+    expect(customerEligibilityCard).toContainReactComponent(Text, {
+      children: 'Customer eligibility',
     });
     expect(customerEligibilityCard).toContainReactComponent(ChoiceList, {
       title: 'Customer eligibility',

--- a/src/components/MethodCard/MethodCard.tsx
+++ b/src/components/MethodCard/MethodCard.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import {
-  LegacyCard as Card,
+  Card,
   ChoiceList,
   LegacyStack as Stack,
   TextField,
   Text,
+  VerticalStack,
 } from '@shopify/polaris';
 import {I18n, useI18n} from '@shopify/react-i18n';
 
@@ -74,7 +75,7 @@ export function MethodCard({
 
   return (
     <Card>
-      <Card.Section>
+      <VerticalStack gap="4">
         <Stack distribution="equalSpacing" alignment="center">
           <Text variant="headingMd" as="h2">
             {title}
@@ -83,14 +84,12 @@ export function MethodCard({
             {getDiscountClassLabel(discountClass, i18n)}
           </Text>
         </Stack>
-      </Card.Section>
-      <Card.Section
-        title={
-          !discountMethodHidden &&
-          i18n.translate('DiscountAppComponents.MethodCard.methodSubtitle')
-        }
-      >
-        <Stack vertical>
+
+        <Text variant="headingMd" as="h2">
+          {!discountMethodHidden &&
+            i18n.translate('DiscountAppComponents.MethodCard.methodSubtitle')}
+        </Text>
+        <VerticalStack gap="4">
           {!discountMethodHidden && (
             <ChoiceList
               title={i18n.translate(
@@ -133,8 +132,8 @@ export function MethodCard({
               {...discountTitle}
             />
           )}
-        </Stack>
-      </Card.Section>
+        </VerticalStack>
+      </VerticalStack>
     </Card>
   );
 }

--- a/src/components/MethodCard/MethodCard.tsx
+++ b/src/components/MethodCard/MethodCard.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import {
   Card,
   ChoiceList,
-  LegacyStack as Stack,
+  VerticalStack,
   TextField,
   Text,
-  VerticalStack,
+  HorizontalStack,
 } from '@shopify/polaris';
 import {I18n, useI18n} from '@shopify/react-i18n';
 
@@ -76,14 +76,14 @@ export function MethodCard({
   return (
     <Card>
       <VerticalStack gap="4">
-        <Stack distribution="equalSpacing" alignment="center">
+        <HorizontalStack align="start" gap="1">
           <Text variant="headingMd" as="h2">
             {title}
           </Text>
           <Text as="span" color="subdued">
             {getDiscountClassLabel(discountClass, i18n)}
           </Text>
-        </Stack>
+        </HorizontalStack>
 
         <Text variant="headingMd" as="h2">
           {!discountMethodHidden &&

--- a/src/components/MethodCard/MethodCard.tsx
+++ b/src/components/MethodCard/MethodCard.tsx
@@ -6,6 +6,7 @@ import {
   TextField,
   Text,
   HorizontalStack,
+  Box,
 } from '@shopify/polaris';
 import {I18n, useI18n} from '@shopify/react-i18n';
 
@@ -74,67 +75,69 @@ export function MethodCard({
   };
 
   return (
-    <Card>
-      <VerticalStack gap="4">
-        <HorizontalStack align="start" gap="1">
-          <Text variant="headingMd" as="h2">
-            {title}
-          </Text>
-          <Text as="span" color="subdued">
-            {getDiscountClassLabel(discountClass, i18n)}
-          </Text>
-        </HorizontalStack>
-
-        <Text variant="headingMd" as="h2">
-          {!discountMethodHidden &&
-            i18n.translate('DiscountAppComponents.MethodCard.methodSubtitle')}
-        </Text>
+    <Box paddingBlockEnd="4">
+      <Card padding="4">
         <VerticalStack gap="4">
-          {!discountMethodHidden && (
-            <ChoiceList
-              title={i18n.translate(
-                'DiscountAppComponents.MethodCard.choiceList.title',
-              )}
-              titleHidden
-              choices={[
-                {
-                  value: DiscountMethod.Code,
-                  label: i18n.translate(
-                    'DiscountAppComponents.MethodCard.choiceList.code',
-                  ),
-                },
-                {
-                  value: DiscountMethod.Automatic,
-                  label: i18n.translate(
-                    'DiscountAppComponents.MethodCard.choiceList.automatic',
-                  ),
-                },
-              ]}
-              selected={[discountMethod.value]}
-              onChange={handleChangeMethod}
-            />
-          )}
-          {discountMethod.value === DiscountMethod.Code ? (
-            <DiscountCodeGenerator
-              defaultLength={defaultDiscountCodeLength}
-              discountCode={discountCode}
-            />
-          ) : (
-            <TextField
-              autoComplete="off"
-              label={i18n.translate(
-                'DiscountAppComponents.MethodCard.discountField.label',
-              )}
-              helpText={i18n.translate(
-                'DiscountAppComponents.MethodCard.discountField.helpText',
-              )}
-              maxLength={DISCOUNT_TITLE_MAX_LENGTH}
-              {...discountTitle}
-            />
-          )}
+          <HorizontalStack align="start" gap="1">
+            <Text variant="headingMd" as="h2">
+              {title}
+            </Text>
+            <Text as="span" color="subdued">
+              {getDiscountClassLabel(discountClass, i18n)}
+            </Text>
+          </HorizontalStack>
+
+          <Text variant="headingMd" as="h2">
+            {!discountMethodHidden &&
+              i18n.translate('DiscountAppComponents.MethodCard.methodSubtitle')}
+          </Text>
+          <VerticalStack gap="4">
+            {!discountMethodHidden && (
+              <ChoiceList
+                title={i18n.translate(
+                  'DiscountAppComponents.MethodCard.choiceList.title',
+                )}
+                titleHidden
+                choices={[
+                  {
+                    value: DiscountMethod.Code,
+                    label: i18n.translate(
+                      'DiscountAppComponents.MethodCard.choiceList.code',
+                    ),
+                  },
+                  {
+                    value: DiscountMethod.Automatic,
+                    label: i18n.translate(
+                      'DiscountAppComponents.MethodCard.choiceList.automatic',
+                    ),
+                  },
+                ]}
+                selected={[discountMethod.value]}
+                onChange={handleChangeMethod}
+              />
+            )}
+            {discountMethod.value === DiscountMethod.Code ? (
+              <DiscountCodeGenerator
+                defaultLength={defaultDiscountCodeLength}
+                discountCode={discountCode}
+              />
+            ) : (
+              <TextField
+                autoComplete="off"
+                label={i18n.translate(
+                  'DiscountAppComponents.MethodCard.discountField.label',
+                )}
+                helpText={i18n.translate(
+                  'DiscountAppComponents.MethodCard.discountField.helpText',
+                )}
+                maxLength={DISCOUNT_TITLE_MAX_LENGTH}
+                {...discountTitle}
+              />
+            )}
+          </VerticalStack>
         </VerticalStack>
-      </VerticalStack>
-    </Card>
+      </Card>
+    </Box>
   );
 }
 

--- a/src/components/MethodCard/tests/MethodCard.test.tsx
+++ b/src/components/MethodCard/tests/MethodCard.test.tsx
@@ -1,10 +1,5 @@
 import React from 'react';
-import {
-  LegacyCard as Card,
-  ChoiceList,
-  Text,
-  TextField,
-} from '@shopify/polaris';
+import {Card, ChoiceList, Text, TextField} from '@shopify/polaris';
 import {mockField, mountWithApp} from 'tests/utilities';
 
 import {MethodCard} from '../MethodCard';
@@ -102,8 +97,8 @@ describe('<MethodCard />', () => {
       />,
     );
     expect(methodCard).not.toContainReactComponent(ChoiceList);
-    expect(methodCard).not.toContainReactComponent(Card.Section, {
-      title: 'Method',
+    expect(methodCard).not.toContainReactComponent(Text, {
+      children: 'Method',
     });
   });
 
@@ -118,9 +113,7 @@ describe('<MethodCard />', () => {
       />,
     );
     expect(methodCard).toContainReactComponent(ChoiceList);
-    expect(methodCard).toContainReactComponent(Card.Section, {
-      title: 'Method',
-    });
+    expect(methodCard).toContainReactComponent(Card);
   });
 
   it('toggling the discount method calls onChange for the discountMethod', () => {

--- a/src/components/MinimumRequirementsCard/MinimumRequirementsCard.tsx
+++ b/src/components/MinimumRequirementsCard/MinimumRequirementsCard.tsx
@@ -1,11 +1,11 @@
 import React, {useEffect} from 'react';
 import {
-  LegacyCard as Card,
+  Card,
   TextField,
   ChoiceList,
   InlineError,
   Text,
-  LegacyStack as Stack,
+  VerticalStack,
 } from '@shopify/polaris';
 import {CurrencyCode, I18n, useI18n} from '@shopify/react-i18n';
 
@@ -120,7 +120,7 @@ export function MinimumRequirementsCard({
       renderChildren: (isSelected: boolean) => {
         return (
           isSelected && (
-            <Stack vertical spacing="extraTight">
+            <VerticalStack gap="4">
               <div className={styles.TextField}>
                 <CurrencyField
                   id={SUBTOTAL_FIELD_ID}
@@ -142,7 +142,7 @@ export function MinimumRequirementsCard({
                   message={subtotal.error}
                 />
               )}
-            </Stack>
+            </VerticalStack>
           )
         );
       },
@@ -153,7 +153,7 @@ export function MinimumRequirementsCard({
       renderChildren: (isSelected: boolean) => {
         return (
           isSelected && (
-            <Stack vertical spacing="extraTight">
+            <VerticalStack gap="4">
               <div className={styles.TextField}>
                 <TextField
                   id={QUANTITY_FIELD_ID}
@@ -176,7 +176,7 @@ export function MinimumRequirementsCard({
                   message={quantity.error}
                 />
               )}
-            </Stack>
+            </VerticalStack>
           )
         );
       },
@@ -191,23 +191,25 @@ export function MinimumRequirementsCard({
       : allMinimumRequirementChoices;
 
   return (
-    <Card
-      title={i18n.translate(
-        'DiscountAppComponents.MinimumRequirementsCard.title',
-      )}
-      sectioned
-    >
-      <ChoiceList
-        title={i18n.translate(
-          'DiscountAppComponents.MinimumRequirementsCard.title',
-        )}
-        titleHidden
-        choices={minimumRequirementChoicesToRender}
-        selected={[requirementType.value]}
-        onChange={(nextValue: RequirementType[]) =>
-          requirementType.onChange(nextValue[0])
-        }
-      />
+    <Card>
+      <VerticalStack gap="4">
+        <Text variant="headingMd" as="h2">
+          {i18n.translate(
+            'DiscountAppComponents.MinimumRequirementsCard.title',
+          )}
+        </Text>
+        <ChoiceList
+          title={i18n.translate(
+            'DiscountAppComponents.MinimumRequirementsCard.title',
+          )}
+          titleHidden
+          choices={minimumRequirementChoicesToRender}
+          selected={[requirementType.value]}
+          onChange={(nextValue: RequirementType[]) =>
+            requirementType.onChange(nextValue[0])
+          }
+        />
+      </VerticalStack>
     </Card>
   );
 }

--- a/src/components/MinimumRequirementsCard/MinimumRequirementsCard.tsx
+++ b/src/components/MinimumRequirementsCard/MinimumRequirementsCard.tsx
@@ -6,6 +6,7 @@ import {
   InlineError,
   Text,
   VerticalStack,
+  Box,
 } from '@shopify/polaris';
 import {CurrencyCode, I18n, useI18n} from '@shopify/react-i18n';
 
@@ -191,26 +192,28 @@ export function MinimumRequirementsCard({
       : allMinimumRequirementChoices;
 
   return (
-    <Card>
-      <VerticalStack gap="4">
-        <Text variant="headingMd" as="h2">
-          {i18n.translate(
-            'DiscountAppComponents.MinimumRequirementsCard.title',
-          )}
-        </Text>
-        <ChoiceList
-          title={i18n.translate(
-            'DiscountAppComponents.MinimumRequirementsCard.title',
-          )}
-          titleHidden
-          choices={minimumRequirementChoicesToRender}
-          selected={[requirementType.value]}
-          onChange={(nextValue: RequirementType[]) =>
-            requirementType.onChange(nextValue[0])
-          }
-        />
-      </VerticalStack>
-    </Card>
+    <Box paddingBlockEnd="4">
+      <Card padding="4">
+        <VerticalStack gap="4">
+          <Text variant="headingMd" as="h2">
+            {i18n.translate(
+              'DiscountAppComponents.MinimumRequirementsCard.title',
+            )}
+          </Text>
+          <ChoiceList
+            title={i18n.translate(
+              'DiscountAppComponents.MinimumRequirementsCard.title',
+            )}
+            titleHidden
+            choices={minimumRequirementChoicesToRender}
+            selected={[requirementType.value]}
+            onChange={(nextValue: RequirementType[]) =>
+              requirementType.onChange(nextValue[0])
+            }
+          />
+        </VerticalStack>
+      </Card>
+    </Box>
   );
 }
 

--- a/src/components/PurchaseTypeCard/PurchaseTypeCard.tsx
+++ b/src/components/PurchaseTypeCard/PurchaseTypeCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {ChoiceList, LegacyCard as Card} from '@shopify/polaris';
+import {ChoiceList, Card, Text, VerticalStack} from '@shopify/polaris';
 import {useI18n} from '@shopify/react-i18n';
 
 import type {Field} from '../../types';
@@ -16,40 +16,42 @@ export interface PurchaseTypeCardProps {
 export function PurchaseTypeCard({purchaseType}: PurchaseTypeCardProps) {
   const [i18n] = useI18n();
   return (
-    <Card
-      sectioned
-      title={i18n.translate('DiscountAppComponents.PurchaseTypeList.title')}
-    >
-      <ChoiceList
-        title={i18n.translate(
-          'DiscountAppComponents.PurchaseTypeList.choiceList.title',
-        )}
-        titleHidden
-        selected={[purchaseType.value]}
-        choices={[
-          {
-            label: i18n.translate(
-              'DiscountAppComponents.PurchaseTypeList.choiceList.oneTimePurchase',
-            ),
-            value: PurchaseType.OneTimePurchase,
-          },
-          {
-            label: i18n.translate(
-              'DiscountAppComponents.PurchaseTypeList.choiceList.subscription',
-            ),
-            value: PurchaseType.Subscription,
-          },
-          {
-            label: i18n.translate(
-              'DiscountAppComponents.PurchaseTypeList.choiceList.both',
-            ),
-            value: PurchaseType.Both,
-          },
-        ]}
-        onChange={(purchaseTypeList) => {
-          purchaseType.onChange(purchaseTypeList[0] as PurchaseType);
-        }}
-      />
+    <Card>
+      <VerticalStack gap="4">
+        <Text variant="headingMd" as="h2">
+          {i18n.translate('DiscountAppComponents.PurchaseTypeList.title')}
+        </Text>
+        <ChoiceList
+          title={i18n.translate(
+            'DiscountAppComponents.PurchaseTypeList.choiceList.title',
+          )}
+          titleHidden
+          selected={[purchaseType.value]}
+          choices={[
+            {
+              label: i18n.translate(
+                'DiscountAppComponents.PurchaseTypeList.choiceList.oneTimePurchase',
+              ),
+              value: PurchaseType.OneTimePurchase,
+            },
+            {
+              label: i18n.translate(
+                'DiscountAppComponents.PurchaseTypeList.choiceList.subscription',
+              ),
+              value: PurchaseType.Subscription,
+            },
+            {
+              label: i18n.translate(
+                'DiscountAppComponents.PurchaseTypeList.choiceList.both',
+              ),
+              value: PurchaseType.Both,
+            },
+          ]}
+          onChange={(purchaseTypeList) => {
+            purchaseType.onChange(purchaseTypeList[0] as PurchaseType);
+          }}
+        />
+      </VerticalStack>
     </Card>
   );
 }

--- a/src/components/PurchaseTypeCard/PurchaseTypeCard.tsx
+++ b/src/components/PurchaseTypeCard/PurchaseTypeCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {ChoiceList, Card, Text, VerticalStack} from '@shopify/polaris';
+import {ChoiceList, Card, Text, VerticalStack, Box} from '@shopify/polaris';
 import {useI18n} from '@shopify/react-i18n';
 
 import type {Field} from '../../types';
@@ -16,42 +16,44 @@ export interface PurchaseTypeCardProps {
 export function PurchaseTypeCard({purchaseType}: PurchaseTypeCardProps) {
   const [i18n] = useI18n();
   return (
-    <Card>
-      <VerticalStack gap="4">
-        <Text variant="headingMd" as="h2">
-          {i18n.translate('DiscountAppComponents.PurchaseTypeList.title')}
-        </Text>
-        <ChoiceList
-          title={i18n.translate(
-            'DiscountAppComponents.PurchaseTypeList.choiceList.title',
-          )}
-          titleHidden
-          selected={[purchaseType.value]}
-          choices={[
-            {
-              label: i18n.translate(
-                'DiscountAppComponents.PurchaseTypeList.choiceList.oneTimePurchase',
-              ),
-              value: PurchaseType.OneTimePurchase,
-            },
-            {
-              label: i18n.translate(
-                'DiscountAppComponents.PurchaseTypeList.choiceList.subscription',
-              ),
-              value: PurchaseType.Subscription,
-            },
-            {
-              label: i18n.translate(
-                'DiscountAppComponents.PurchaseTypeList.choiceList.both',
-              ),
-              value: PurchaseType.Both,
-            },
-          ]}
-          onChange={(purchaseTypeList) => {
-            purchaseType.onChange(purchaseTypeList[0] as PurchaseType);
-          }}
-        />
-      </VerticalStack>
-    </Card>
+    <Box paddingBlockEnd="4">
+      <Card padding="4">
+        <VerticalStack gap="4">
+          <Text variant="headingMd" as="h2">
+            {i18n.translate('DiscountAppComponents.PurchaseTypeList.title')}
+          </Text>
+          <ChoiceList
+            title={i18n.translate(
+              'DiscountAppComponents.PurchaseTypeList.choiceList.title',
+            )}
+            titleHidden
+            selected={[purchaseType.value]}
+            choices={[
+              {
+                label: i18n.translate(
+                  'DiscountAppComponents.PurchaseTypeList.choiceList.oneTimePurchase',
+                ),
+                value: PurchaseType.OneTimePurchase,
+              },
+              {
+                label: i18n.translate(
+                  'DiscountAppComponents.PurchaseTypeList.choiceList.subscription',
+                ),
+                value: PurchaseType.Subscription,
+              },
+              {
+                label: i18n.translate(
+                  'DiscountAppComponents.PurchaseTypeList.choiceList.both',
+                ),
+                value: PurchaseType.Both,
+              },
+            ]}
+            onChange={(purchaseTypeList) => {
+              purchaseType.onChange(purchaseTypeList[0] as PurchaseType);
+            }}
+          />
+        </VerticalStack>
+      </Card>
+    </Box>
   );
 }

--- a/src/components/PurchaseTypeCard/tests/PurchaseTypeList.test.tsx
+++ b/src/components/PurchaseTypeCard/tests/PurchaseTypeList.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {LegacyCard as Card, ChoiceList} from '@shopify/polaris';
+import {Card, ChoiceList, Text} from '@shopify/polaris';
 import {mountWithApp, mockField} from 'tests/utilities';
 
 import {PurchaseTypeCard} from '../PurchaseTypeCard';
@@ -21,10 +21,10 @@ describe('<PurchaseTypeList />', () => {
   it('shows the card title', () => {
     const purchaseTypeCard = mountWithApp(mountWithProps());
 
-    expect(purchaseTypeCard).toContainReactComponent(Card, {
-      title: 'Purchase type',
+    expect(purchaseTypeCard).toContainReactComponent(Card);
+    expect(purchaseTypeCard).toContainReactComponent(Text, {
+      children: 'Purchase type',
     });
-
     expect(purchaseTypeCard).toContainReactComponent(ChoiceList, {
       title: 'Purchase type',
       titleHidden: true,

--- a/src/components/SummaryCard/SummaryCard.tsx
+++ b/src/components/SummaryCard/SummaryCard.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @shopify/typescript/prefer-pascal-case-enums */
 import React from 'react';
 import {useI18n} from '@shopify/react-i18n';
-import {List, Card, VerticalStack, Text} from '@shopify/polaris';
+import {List, Card, VerticalStack, Text, Box} from '@shopify/polaris';
 
 import {
   ActiveDates,
@@ -115,63 +115,67 @@ export function SummaryCard(props: SummaryCardProps) {
   );
 
   return (
-    <Card>
-      <VerticalStack gap="4">
-        <Text variant="headingMd" as="h2">
-          {i18n.translate('title', I18N_SCOPE)}
-        </Text>
+    <Box paddingBlockEnd="4">
+      <Card padding="4">
+        <VerticalStack gap="4">
+          <Text variant="headingMd" as="h2">
+            {i18n.translate('title', I18N_SCOPE)}
+          </Text>
 
-        <VerticalStack>
-          <Header {...props.header} />
+          <VerticalStack>
+            <Header {...props.header} />
 
-          {showDetailsSection && (
-            <VerticalStack>
-              <Text variant="headingXs" as="h3">
-                {i18n.translate('details', I18N_SCOPE)}
-              </Text>
+            {showDetailsSection && (
+              <VerticalStack>
+                <Text variant="headingXs" as="h3">
+                  {i18n.translate('details', I18N_SCOPE)}
+                </Text>
 
-              <List type="bullet">
-                {props.additionalDetails?.map((detail) => (
-                  <List.Item key={detail.replace(/\s/g, '-')}>
-                    {detail}
-                  </List.Item>
-                ))}
+                <List type="bullet">
+                  {props.additionalDetails?.map((detail) => (
+                    <List.Item key={detail.replace(/\s/g, '-')}>
+                      {detail}
+                    </List.Item>
+                  ))}
 
-                {props.appliesToPurchaseType && (
-                  <AppliesToPurchaseType {...props.appliesToPurchaseType} />
-                )}
+                  {props.appliesToPurchaseType && (
+                    <AppliesToPurchaseType {...props.appliesToPurchaseType} />
+                  )}
 
-                {props.recurringPayment && (
-                  <RecurringPayment {...props.recurringPayment} />
-                )}
+                  {props.recurringPayment && (
+                    <RecurringPayment {...props.recurringPayment} />
+                  )}
 
-                {props.selectedCountries && (
-                  <SelectedCountries {...props.selectedCountries} />
-                )}
+                  {props.selectedCountries && (
+                    <SelectedCountries {...props.selectedCountries} />
+                  )}
 
-                {props.maximumShippingPrice && (
-                  <MaximumShippingPrice {...props.maximumShippingPrice} />
-                )}
+                  {props.maximumShippingPrice && (
+                    <MaximumShippingPrice {...props.maximumShippingPrice} />
+                  )}
 
-                {props.minimumRequirements && (
-                  <MinimumRequirements {...props.minimumRequirements} />
-                )}
+                  {props.minimumRequirements && (
+                    <MinimumRequirements {...props.minimumRequirements} />
+                  )}
 
-                {props.customerEligibility && (
-                  <CustomerEligibility {...props.customerEligibility} />
-                )}
+                  {props.customerEligibility && (
+                    <CustomerEligibility {...props.customerEligibility} />
+                  )}
 
-                {props.usageLimits && <UsageLimits {...props.usageLimits} />}
+                  {props.usageLimits && <UsageLimits {...props.usageLimits} />}
 
-                {props.combinations && <Combinations {...props.combinations} />}
+                  {props.combinations && (
+                    <Combinations {...props.combinations} />
+                  )}
 
-                {props.activeDates && <ActiveDates {...props.activeDates} />}
-              </List>
-            </VerticalStack>
-          )}
+                  {props.activeDates && <ActiveDates {...props.activeDates} />}
+                </List>
+              </VerticalStack>
+            )}
+          </VerticalStack>
+          <Performance {...props.performance} />
         </VerticalStack>
-        <Performance {...props.performance} />
-      </VerticalStack>
-    </Card>
+      </Card>
+    </Box>
   );
 }

--- a/src/components/SummaryCard/SummaryCard.tsx
+++ b/src/components/SummaryCard/SummaryCard.tsx
@@ -1,12 +1,7 @@
 /* eslint-disable @shopify/typescript/prefer-pascal-case-enums */
 import React from 'react';
 import {useI18n} from '@shopify/react-i18n';
-import {
-  List,
-  LegacyCard as Card,
-  LegacyStack as Stack,
-  Text,
-} from '@shopify/polaris';
+import {List, Card, VerticalStack, Text} from '@shopify/polaris';
 
 import {
   ActiveDates,
@@ -120,13 +115,17 @@ export function SummaryCard(props: SummaryCardProps) {
   );
 
   return (
-    <Card title={i18n.translate('title', I18N_SCOPE)}>
-      <Card.Section>
-        <Stack vertical spacing="loose">
+    <Card>
+      <VerticalStack gap="4">
+        <Text variant="headingMd" as="h2">
+          {i18n.translate('title', I18N_SCOPE)}
+        </Text>
+
+        <VerticalStack>
           <Header {...props.header} />
 
           {showDetailsSection && (
-            <Stack vertical spacing="tight">
+            <VerticalStack>
               <Text variant="headingXs" as="h3">
                 {i18n.translate('details', I18N_SCOPE)}
               </Text>
@@ -168,11 +167,11 @@ export function SummaryCard(props: SummaryCardProps) {
 
                 {props.activeDates && <ActiveDates {...props.activeDates} />}
               </List>
-            </Stack>
+            </VerticalStack>
           )}
-        </Stack>
-      </Card.Section>
-      <Performance {...props.performance} />
+        </VerticalStack>
+        <Performance {...props.performance} />
+      </VerticalStack>
     </Card>
   );
 }

--- a/src/components/SummaryCard/components/Header/Header.tsx
+++ b/src/components/SummaryCard/components/Header/Header.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import {I18n, useI18n} from '@shopify/react-i18n';
-import {Badge, List, LegacyStack as Stack, Text} from '@shopify/polaris';
+import {
+  Badge,
+  HorizontalStack,
+  List,
+  Text,
+  VerticalStack,
+} from '@shopify/polaris';
 
 import {DiscountMethod, DiscountStatus} from '~/constants';
 
@@ -56,22 +62,22 @@ export function Header(props: HeaderProps) {
   const trimmedDescriptor = discountDescriptor.trim();
 
   return (
-    <Stack vertical spacing="loose">
+    <VerticalStack gap="4">
       {trimmedDescriptor ? (
-        <Stack distribution="equalSpacing" alignment="center" wrap>
+        <HorizontalStack align="center">
           <Text variant="headingMd" as="h3">
             {trimmedDescriptor}
           </Text>
 
           {isEditing(props) && renderBadgeForStatus(props.discountStatus, i18n)}
-        </Stack>
+        </HorizontalStack>
       ) : (
         <Text as="span" fontWeight="semibold" color="subdued">
           {i18n.translate(`emptyState.${discountMethod}`, I18N_SCOPE)}
         </Text>
       )}
 
-      <Stack vertical spacing="tight">
+      <VerticalStack gap="4">
         <Text variant="headingXs" as="h3">
           {i18n.translate('typeAndMethod', I18N_SCOPE)}
         </Text>
@@ -81,8 +87,8 @@ export function Header(props: HeaderProps) {
             {i18n.translate(`discountMethod.${discountMethod}`, I18N_SCOPE)}
           </List.Item>
         </List>
-      </Stack>
-    </Stack>
+      </VerticalStack>
+    </VerticalStack>
   );
 }
 

--- a/src/components/SummaryCard/components/Performance/Performance.tsx
+++ b/src/components/SummaryCard/components/Performance/Performance.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {useI18n} from '@shopify/react-i18n';
-import {Card, List, Text, VerticalStack} from '@shopify/polaris';
+import {List, Text, VerticalStack} from '@shopify/polaris';
 import {Redirect} from '@shopify/app-bridge/actions';
 
 import {AppBridgeLink} from '../../../AppBridgeLink';

--- a/src/components/SummaryCard/components/Performance/Performance.tsx
+++ b/src/components/SummaryCard/components/Performance/Performance.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {useI18n} from '@shopify/react-i18n';
-import {LegacyCard as Card, List, Text, VerticalStack} from '@shopify/polaris';
+import {Card, List, Text, VerticalStack} from '@shopify/polaris';
 import {Redirect} from '@shopify/app-bridge/actions';
 
 import {AppBridgeLink} from '../../../AppBridgeLink';
@@ -54,42 +54,43 @@ export function Performance({
     status === DiscountStatus.Active || status === DiscountStatus.Expired;
 
   return (
-    <Card.Section title={i18n.translate('title', I18N_SCOPE)}>
-      <VerticalStack>
-        {status === DiscountStatus.Scheduled && (
-          <Text as="span" color="subdued">
-            {i18n.translate('notActive', I18N_SCOPE)}
-          </Text>
-        )}
-        {isActiveOrExpired && (
-          <>
-            <List type="bullet">
+    <VerticalStack>
+      <Text variant="headingXs" as="h3">
+        {i18n.translate('title', I18N_SCOPE)}
+      </Text>
+      {status === DiscountStatus.Scheduled && (
+        <Text as="span" color="subdued">
+          {i18n.translate('notActive', I18N_SCOPE)}
+        </Text>
+      )}
+      {isActiveOrExpired && (
+        <>
+          <List type="bullet">
+            <List.Item>
+              {i18n.translate('usageCount', I18N_SCOPE, {usageCount})}
+            </List.Item>
+            {totalSales && (
               <List.Item>
-                {i18n.translate('usageCount', I18N_SCOPE, {usageCount})}
+                {i18n.translate('totalSales', I18N_SCOPE, {
+                  totalSales: i18n.formatCurrency(Number(totalSales.amount), {
+                    currency: totalSales.currencyCode,
+                  }),
+                })}
               </List.Item>
-              {totalSales && (
-                <List.Item>
-                  {i18n.translate('totalSales', I18N_SCOPE, {
-                    totalSales: i18n.formatCurrency(Number(totalSales.amount), {
-                      currency: totalSales.currencyCode,
-                    }),
-                  })}
-                </List.Item>
-              )}
-            </List>
-            {hasReports && discountMethod === DiscountMethod.Code && (
-              <p>
-                <AppBridgeLink
-                  action={Redirect.Action.ADMIN_PATH}
-                  url={CODE_DISCOUNT_ADMIN_REPORT_URL}
-                >
-                  {i18n.translate('performanceLink', I18N_SCOPE)}
-                </AppBridgeLink>
-              </p>
             )}
-          </>
-        )}
-      </VerticalStack>
-    </Card.Section>
+          </List>
+          {hasReports && discountMethod === DiscountMethod.Code && (
+            <p>
+              <AppBridgeLink
+                action={Redirect.Action.ADMIN_PATH}
+                url={CODE_DISCOUNT_ADMIN_REPORT_URL}
+              >
+                {i18n.translate('performanceLink', I18N_SCOPE)}
+              </AppBridgeLink>
+            </p>
+          )}
+        </>
+      )}
+    </VerticalStack>
   );
 }

--- a/src/components/SummaryCard/tests/SummaryCard.test.tsx
+++ b/src/components/SummaryCard/tests/SummaryCard.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {LegacyCard as Card, List, Text} from '@shopify/polaris';
+import {Card, List, Text} from '@shopify/polaris';
 import {CurrencyCode} from '@shopify/react-i18n';
 
 import {SummaryCard, SummaryCardProps} from '../SummaryCard';
@@ -44,8 +44,9 @@ describe('<SummaryCard />', () => {
   it('renders a default SummaryCard', () => {
     const summaryCard = mountWithApp(<SummaryCard {...mockProps} />);
 
-    expect(summaryCard).toContainReactComponent(Card, {
-      title: 'Summary',
+    expect(summaryCard).toContainReactComponent(Card);
+    expect(summaryCard).toContainReactComponent(Text, {
+      children: 'My cool discount',
     });
     expect(summaryCard).toContainReactComponent(Header, mockProps.header);
   });

--- a/src/components/UsageLimitsCard/UsageLimitsCard.tsx
+++ b/src/components/UsageLimitsCard/UsageLimitsCard.tsx
@@ -1,11 +1,11 @@
 import React, {useEffect, useState} from 'react';
 import {
-  LegacyCard as Card,
+  Card,
   ChoiceList,
   TextField,
-  LegacyStack as Stack,
   Text,
   InlineError,
+  VerticalStack,
 } from '@shopify/polaris';
 import {useI18n} from '@shopify/react-i18n';
 
@@ -95,8 +95,11 @@ export function UsageLimitsCard(props: UsageLimitsCardProps) {
   };
 
   return (
-    <Card title={i18n.translate('DiscountAppComponents.UsageLimitsCard.title')}>
-      <Card.Section>
+    <Card>
+      <VerticalStack gap="4">
+        <Text variant="headingMd" as="h2">
+          {i18n.translate('DiscountAppComponents.UsageLimitsCard.title')}
+        </Text>
         <ChoiceList
           title={i18n.translate(
             'DiscountAppComponents.UsageLimitsCard.options',
@@ -116,7 +119,7 @@ export function UsageLimitsCard(props: UsageLimitsCardProps) {
               ),
               value: UsageLimitType.TotalUsageLimit,
               renderChildren: (isSelected: boolean) => (
-                <Stack vertical spacing="extraTight">
+                <VerticalStack>
                   {isSelected && (
                     <div className={styles.TotalUsageLimitTextField}>
                       <TextField
@@ -150,7 +153,7 @@ export function UsageLimitsCard(props: UsageLimitsCardProps) {
                       message={totalUsageLimit.error}
                     />
                   )}
-                </Stack>
+                </VerticalStack>
               ),
             },
             {
@@ -162,14 +165,14 @@ export function UsageLimitsCard(props: UsageLimitsCardProps) {
           ]}
           onChange={handleUsageLimitsChoicesChange}
         />
-      </Card.Section>
+      </VerticalStack>
       {isShowRecurringPaymentSection(props) && (
-        <Card.Section>
+        <VerticalStack gap="4">
           <RecurringPayment
             recurringPaymentType={props.recurringPaymentType}
             recurringPaymentLimit={props.recurringPaymentLimit}
           />
-        </Card.Section>
+        </VerticalStack>
       )}
     </Card>
   );

--- a/src/components/UsageLimitsCard/UsageLimitsCard.tsx
+++ b/src/components/UsageLimitsCard/UsageLimitsCard.tsx
@@ -6,6 +6,7 @@ import {
   Text,
   InlineError,
   VerticalStack,
+  Box,
 } from '@shopify/polaris';
 import {useI18n} from '@shopify/react-i18n';
 
@@ -95,86 +96,88 @@ export function UsageLimitsCard(props: UsageLimitsCardProps) {
   };
 
   return (
-    <Card>
-      <VerticalStack gap="4">
-        <Text variant="headingMd" as="h2">
-          {i18n.translate('DiscountAppComponents.UsageLimitsCard.title')}
-        </Text>
-        <ChoiceList
-          title={i18n.translate(
-            'DiscountAppComponents.UsageLimitsCard.options',
-          )}
-          titleHidden
-          allowMultiple
-          selected={[
-            ...(showUsageLimit ? [UsageLimitType.TotalUsageLimit] : []),
-            ...(oncePerCustomer.value
-              ? [UsageLimitType.OncePerCustomerLimit]
-              : []),
-          ]}
-          choices={[
-            {
-              label: i18n.translate(
-                'DiscountAppComponents.UsageLimitsCard.totalUsageLimitLabel',
-              ),
-              value: UsageLimitType.TotalUsageLimit,
-              renderChildren: (isSelected: boolean) => (
-                <VerticalStack>
-                  {isSelected && (
-                    <div className={styles.TotalUsageLimitTextField}>
-                      <TextField
-                        id={DISCOUNT_TOTAL_USAGE_LIMIT_FIELD}
-                        label={i18n.translate(
-                          'DiscountAppComponents.UsageLimitsCard.totalUsageLimitLabel',
-                        )}
-                        autoComplete="off"
-                        labelHidden
-                        value={totalUsageLimit.value || ''}
-                        onChange={(nextValue) => {
-                          totalUsageLimit.onChange(
-                            forcePositiveInteger(nextValue),
-                          );
-                        }}
-                        onBlur={totalUsageLimit.onBlur}
-                        error={Boolean(totalUsageLimit.error)}
-                      />
-                    </div>
-                  )}
-                  {isRecurring && (
-                    <Text as="span" color="subdued">
-                      {i18n.translate(
-                        'DiscountAppComponents.UsageLimitsCard.totalUsageLimitHelpTextSubscription',
-                      )}
-                    </Text>
-                  )}
-                  {isSelected && totalUsageLimit.error && (
-                    <InlineError
-                      fieldID={DISCOUNT_TOTAL_USAGE_LIMIT_FIELD}
-                      message={totalUsageLimit.error}
-                    />
-                  )}
-                </VerticalStack>
-              ),
-            },
-            {
-              label: i18n.translate(
-                'DiscountAppComponents.UsageLimitsCard.oncePerCustomerLimitLabel',
-              ),
-              value: UsageLimitType.OncePerCustomerLimit,
-            },
-          ]}
-          onChange={handleUsageLimitsChoicesChange}
-        />
-      </VerticalStack>
-      {isShowRecurringPaymentSection(props) && (
+    <Box paddingBlockEnd="4">
+      <Card padding="4">
         <VerticalStack gap="4">
-          <RecurringPayment
-            recurringPaymentType={props.recurringPaymentType}
-            recurringPaymentLimit={props.recurringPaymentLimit}
+          <Text variant="headingMd" as="h2">
+            {i18n.translate('DiscountAppComponents.UsageLimitsCard.title')}
+          </Text>
+          <ChoiceList
+            title={i18n.translate(
+              'DiscountAppComponents.UsageLimitsCard.options',
+            )}
+            titleHidden
+            allowMultiple
+            selected={[
+              ...(showUsageLimit ? [UsageLimitType.TotalUsageLimit] : []),
+              ...(oncePerCustomer.value
+                ? [UsageLimitType.OncePerCustomerLimit]
+                : []),
+            ]}
+            choices={[
+              {
+                label: i18n.translate(
+                  'DiscountAppComponents.UsageLimitsCard.totalUsageLimitLabel',
+                ),
+                value: UsageLimitType.TotalUsageLimit,
+                renderChildren: (isSelected: boolean) => (
+                  <VerticalStack>
+                    {isSelected && (
+                      <div className={styles.TotalUsageLimitTextField}>
+                        <TextField
+                          id={DISCOUNT_TOTAL_USAGE_LIMIT_FIELD}
+                          label={i18n.translate(
+                            'DiscountAppComponents.UsageLimitsCard.totalUsageLimitLabel',
+                          )}
+                          autoComplete="off"
+                          labelHidden
+                          value={totalUsageLimit.value || ''}
+                          onChange={(nextValue) => {
+                            totalUsageLimit.onChange(
+                              forcePositiveInteger(nextValue),
+                            );
+                          }}
+                          onBlur={totalUsageLimit.onBlur}
+                          error={Boolean(totalUsageLimit.error)}
+                        />
+                      </div>
+                    )}
+                    {isRecurring && (
+                      <Text as="span" color="subdued">
+                        {i18n.translate(
+                          'DiscountAppComponents.UsageLimitsCard.totalUsageLimitHelpTextSubscription',
+                        )}
+                      </Text>
+                    )}
+                    {isSelected && totalUsageLimit.error && (
+                      <InlineError
+                        fieldID={DISCOUNT_TOTAL_USAGE_LIMIT_FIELD}
+                        message={totalUsageLimit.error}
+                      />
+                    )}
+                  </VerticalStack>
+                ),
+              },
+              {
+                label: i18n.translate(
+                  'DiscountAppComponents.UsageLimitsCard.oncePerCustomerLimitLabel',
+                ),
+                value: UsageLimitType.OncePerCustomerLimit,
+              },
+            ]}
+            onChange={handleUsageLimitsChoicesChange}
           />
         </VerticalStack>
-      )}
-    </Card>
+        {isShowRecurringPaymentSection(props) && (
+          <VerticalStack gap="4">
+            <RecurringPayment
+              recurringPaymentType={props.recurringPaymentType}
+              recurringPaymentLimit={props.recurringPaymentLimit}
+            />
+          </VerticalStack>
+        )}
+      </Card>
+    </Box>
   );
 }
 

--- a/src/components/UsageLimitsCard/components/RecurringPayment/RecurringPayment.tsx
+++ b/src/components/UsageLimitsCard/components/RecurringPayment/RecurringPayment.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
   ChoiceList,
-  LegacyStack as Stack,
   TextField,
   Text,
   InlineError,
@@ -49,7 +48,7 @@ export function RecurringPayment({
       renderChildren: (isSelected: boolean) => {
         return (
           isSelected && (
-            <Stack vertical spacing="extraTight">
+            <VerticalStack gap="4">
               <div className={styles.RecurringPaymentTextField}>
                 <TextField
                   id={RECURRING_PAYMENT_FIELD_ID}
@@ -79,7 +78,7 @@ export function RecurringPayment({
                   message={recurringPaymentLimit.error}
                 />
               )}
-            </Stack>
+            </VerticalStack>
           )
         );
       },

--- a/src/components/UsageLimitsCard/components/RecurringPayment/RecurringPayment.tsx
+++ b/src/components/UsageLimitsCard/components/RecurringPayment/RecurringPayment.tsx
@@ -92,7 +92,7 @@ export function RecurringPayment({
   ];
 
   return (
-    <VerticalStack>
+    <VerticalStack gap="4">
       <Text variant="headingXs" as="h3">
         {i18n.translate('DiscountAppComponents.RecurringPayment.title')}
       </Text>

--- a/src/components/UsageLimitsCard/tests/UsageLimitsCard.test.tsx
+++ b/src/components/UsageLimitsCard/tests/UsageLimitsCard.test.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import {
   ChoiceList,
   TextField,
-  LegacyCard as Card,
+  Card,
   InlineError,
-  LegacyStack as Stack,
+  VerticalStack,
   Text,
 } from '@shopify/polaris';
 import {mockField, mountWithApp} from 'tests/utilities';
@@ -28,8 +28,9 @@ describe('UsageLimitsCard', () => {
   it('renders Card with title', () => {
     const usageLimits = mountWithApp(<UsageLimitsCard {...defaultProps} />);
 
-    expect(usageLimits).toContainReactComponent(Card, {
-      title: 'Maximum discount uses',
+    expect(usageLimits).toContainReactComponent(Card);
+    expect(usageLimits).toContainReactComponent(Text, {
+      children: 'Maximum discount uses',
     });
   });
 
@@ -89,9 +90,7 @@ describe('UsageLimitsCard', () => {
     it('displays usage limit option in a stack', () => {
       const usageLimits = mountWithApp(<UsageLimitsCard {...defaultProps} />);
 
-      expect(usageLimits).toContainReactComponent(Stack, {
-        spacing: 'extraTight',
-      });
+      expect(usageLimits).toContainReactComponent(VerticalStack);
     });
 
     it('displays total usage limit text field when totalUsageLimit is a number', () => {
@@ -103,7 +102,7 @@ describe('UsageLimitsCard', () => {
         />,
       );
 
-      const stack = usageLimits.find(Stack);
+      const stack = usageLimits.find(VerticalStack);
 
       expect(stack).toContainReactComponent(TextField, {
         value: totalUsageLimit,
@@ -120,7 +119,7 @@ describe('UsageLimitsCard', () => {
         />,
       );
 
-      const stack = usageLimits.find(Stack);
+      const stack = usageLimits.find(VerticalStack);
 
       expect(stack).toContainReactComponent(Text, {
         children: 'A subscription with many payments will count as one use.',


### PR DESCRIPTION
### Description

Fixes: https://github.com/Shopify/discount-app-components/issues/67

Removing the use of legacy components in the CombinationCard and adding a Box around components to help with layouts.

Updates:

| Component | Before | After |
| -------------| ------ | ------ |
| DiscountPagePattern | ![image](https://github.com/Shopify/discount-app-components/assets/9765013/b514e44e-f0e6-4c95-bbfd-542c8e1a1469) | ![image](https://github.com/Shopify/discount-app-components/assets/9765013/26ab47a6-bd97-4376-974d-63acee46bbfa) |

### Tophat

1. run `yarn storybook`
2. Ensure components are rendered properly and look the same or better than before 😄 
