### PR TITLE
refactor: convert aliased paths to relative paths

### DIFF
--- a/.changeset/fair-ligers-care.md
+++ b/.changeset/fair-ligers-care.md
@@ -1,0 +1,5 @@
+---
+'@shopify/discount-app-components': patch
+---
+
+use relative paths instead of aliases

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -17,7 +17,6 @@ module.exports = {
 
     config.resolve.alias = {
       ...config.resolve.alias,
-      '~': path.resolve(__dirname, '../src/'),
       '@locales': path.resolve(__dirname, '../locales/'),
       locales_dynamic: path.resolve(__dirname, '../locales/'),
     };

--- a/loom.config.ts
+++ b/loom.config.ts
@@ -68,7 +68,6 @@ function jestAdjustmentsPlugin() {
           '^tests/(.*)': '<rootDir>/tests/$1',
           '\\.s?css$': require.resolve('./config/jest-transform-style'),
           "^@locales(.*)$": "<rootDir>/locales$1",
-          "^~(.*)$": "<rootDir>/src$1",
         }));
 
         configuration.jestConfig?.hook((config) => ({
@@ -135,7 +134,6 @@ function rollupAliasPlugin() {
   return rollupPlugins(() => [
       alias({
         entries: [
-          { find: '~', replacement: path.resolve(projectRootDir, 'src')},
           { find: '@locales', replacement: './locales' },
         ],
       })

--- a/src/components/ActiveDatesCard/ActiveDatesCard.tsx
+++ b/src/components/ActiveDatesCard/ActiveDatesCard.tsx
@@ -5,14 +5,13 @@ import {useI18n} from '@shopify/react-i18n';
 
 import {DatePicker} from '../DatePicker';
 import {TimePicker} from '../TimePicker';
-
 import {
   getDateInUTC,
   getDateTimeInShopTimeZone,
   getNewDateAtEndOfDay,
-} from '~/utilities/dates';
-import {DEFAULT_WEEK_START_DAY, Weekday} from '~/constants';
-import type {DateTime, Field} from '~/types';
+} from '../../utilities/dates';
+import {DEFAULT_WEEK_START_DAY, Weekday} from '../../constants';
+import type {DateTime, Field} from '../../types';
 
 export interface ActiveDatesCardProps {
   /**

--- a/src/components/ActiveDatesCard/tests/ActiveDatesCard.test.tsx
+++ b/src/components/ActiveDatesCard/tests/ActiveDatesCard.test.tsx
@@ -7,8 +7,7 @@ import MockDate from 'mockdate';
 import {ActiveDatesCard} from '../ActiveDatesCard';
 import {DatePicker} from '../../DatePicker';
 import {TimePicker} from '../../TimePicker';
-
-import {Weekday} from '~/constants';
+import {Weekday} from '../../../constants';
 
 describe('<ActiveDatesCard />', () => {
   const mockProps = {

--- a/src/components/AppBridgeLink/AppBridgeLink.tsx
+++ b/src/components/AppBridgeLink/AppBridgeLink.tsx
@@ -3,8 +3,8 @@ import {useAppBridge} from '@shopify/app-bridge-react';
 import {Redirect} from '@shopify/app-bridge/actions';
 import {Link} from '@shopify/polaris';
 
-import {handleRedirect} from '~/utilities/navigation';
-import type {LinkAction} from '~/types';
+import {handleRedirect} from '../../utilities/navigation';
+import type {LinkAction} from '../../types';
 
 export interface AppBridgeLinkProps {
   children?: React.ReactNode;

--- a/src/components/CombinationCard/CombinationCard.tsx
+++ b/src/components/CombinationCard/CombinationCard.tsx
@@ -11,14 +11,14 @@ import {
 } from '@shopify/polaris';
 import {I18n, useI18n} from '@shopify/react-i18n';
 
-import {HelpText} from './components';
-
-import {DiscountClass} from '~/constants';
+import {DiscountClass} from '../../constants';
 import type {
   CombinableDiscountTypes,
   CombinableDiscountCounts,
   Field,
-} from '~/types';
+} from '../../types';
+
+import {HelpText} from './components';
 
 const I18N_SCOPE = {
   scope: 'DiscountAppComponents.CombinationCard',

--- a/src/components/CombinationCard/components/HelpText/HelpText.tsx
+++ b/src/components/CombinationCard/components/HelpText/HelpText.tsx
@@ -5,7 +5,7 @@ import {useAppBridge} from '@shopify/app-bridge-react';
 import {Modal} from '@shopify/app-bridge/actions';
 import {Action} from '@shopify/app-bridge/actions/Modal';
 
-import {DiscountClass} from '~/constants';
+import {DiscountClass} from '../../../../constants';
 
 const DISCOUNT_COMBINATION_MODAL_APP_BRIDGE_URL =
   'shopify://app-bridge/modal/discounts-combinations';

--- a/src/components/CombinationCard/components/HelpText/tests/HelpText.test.tsx
+++ b/src/components/CombinationCard/components/HelpText/tests/HelpText.test.tsx
@@ -5,8 +5,7 @@ import {Action} from '@shopify/app-bridge/actions/Modal';
 import {composeGid} from '@shopify/admin-graphql-api-utilities';
 
 import {HelpText} from '../HelpText';
-
-import {DiscountClass} from '~/constants';
+import {DiscountClass} from '../../../../../constants';
 
 jest.mock('@shopify/app-bridge-react', () => ({
   ...jest.requireActual('@shopify/app-bridge-react'),

--- a/src/components/CombinationCard/tests/CombinationCard.test.tsx
+++ b/src/components/CombinationCard/tests/CombinationCard.test.tsx
@@ -6,8 +6,7 @@ import {composeGid} from '@shopify/admin-graphql-api-utilities';
 import {CombinationCard} from '../CombinationCard';
 import {HelpText} from '../components';
 import type {CombinationCardProps} from '../CombinationCard';
-
-import {DiscountClass} from '~/constants';
+import {DiscountClass} from '../../../constants';
 
 describe('<CombinationCard />', () => {
   const mockProps: CombinationCardProps = {

--- a/src/components/CountriesAndRatesCard/CountriesAndRatesCard.tsx
+++ b/src/components/CountriesAndRatesCard/CountriesAndRatesCard.tsx
@@ -12,12 +12,16 @@ import {CurrencyCode, useI18n} from '@shopify/react-i18n';
 
 import {SelectedItemsList} from '../SelectedItemsList';
 import {CurrencyField} from '../CurrencyField';
+import type {
+  Field,
+  PositiveNumericString,
+  CountryCode,
+  Country,
+} from '../../types';
+import {CountrySelectionType} from '../../constants';
 
 import styles from './CountriesAndRatesCard.scss';
 import {useLocalizeCountry} from './utilities';
-
-import type {Field, PositiveNumericString, CountryCode, Country} from '~/types';
-import {CountrySelectionType} from '~/constants';
 
 const EXCLUDE_SHIPPING_RATES_FIELD_ID = 'excludeShippingRatesOverTextField';
 

--- a/src/components/CountriesAndRatesCard/tests/CountriesAndRatesCard.test.tsx
+++ b/src/components/CountriesAndRatesCard/tests/CountriesAndRatesCard.test.tsx
@@ -11,9 +11,8 @@ import {mountWithApp, mockField} from 'tests/utilities';
 
 import {CountriesAndRatesCard} from '../CountriesAndRatesCard';
 import {CountrySelectionType, SupportedCountryCode} from '../../../constants';
-
-import {CurrencyField} from '~/components/CurrencyField';
-import {SelectedItemsList} from '~/components/SelectedItemsList';
+import {CurrencyField} from '../../CurrencyField';
+import {SelectedItemsList} from '../../SelectedItemsList';
 
 describe('<CountriesAndRatesCard />', () => {
   const mockProps = {

--- a/src/components/CountriesAndRatesCard/utilities.ts
+++ b/src/components/CountriesAndRatesCard/utilities.ts
@@ -3,8 +3,8 @@ import {useI18n} from '@shopify/react-i18n';
 import type {
   REST_OF_WORLD,
   SupportedCountryCode as CountryCode,
-} from '~/constants';
-import type {Country} from '~/types';
+} from '../../constants';
+import type {Country} from '../../types';
 
 /**
  * @returns a function that takes a country code or `REST_OF_WORLD` and returns a localized country object

--- a/src/components/CustomerEligibilityCard/tests/CustomerEligibilityCard.test.tsx
+++ b/src/components/CustomerEligibilityCard/tests/CustomerEligibilityCard.test.tsx
@@ -10,11 +10,10 @@ import {
   SelectedCustomersList,
 } from '../CustomerEligibilityCard';
 import styles from '../CustomerEligibilityCard.scss';
-
-import {Eligibility} from '~/constants';
-import {SelectedItemsList} from '~/components/SelectedItemsList';
-import {AppBridgeLink} from '~/components/AppBridgeLink';
-import type {Customer, CustomerSegment} from '~/types';
+import {Eligibility} from '../../../constants';
+import {SelectedItemsList} from '../../SelectedItemsList';
+import {AppBridgeLink} from '../../AppBridgeLink';
+import type {Customer, CustomerSegment} from '../../../types';
 
 describe('<CustomerEligibilityCard />', () => {
   const customerSegmentsList = [

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -10,13 +10,13 @@ import {CalendarMajor} from '@shopify/polaris-icons';
 import {timeParse, timeFormat} from 'd3-time-format';
 import {useI18n} from '@shopify/react-i18n';
 
-import type {DateTime, Field} from '~/types';
-import {Weekday, DEFAULT_WEEK_START_DAY} from '~/constants';
+import type {DateTime, Field} from '../../types';
+import {Weekday, DEFAULT_WEEK_START_DAY} from '../../constants';
 import {
   getDateInUTC,
   getDateTimeInShopTimeZone,
   getNewDateAtStartOfDay,
-} from '~/utilities/dates';
+} from '../../utilities/dates';
 
 const DATE_BLOCKLIST_REGEX = /[^\d-]/g;
 

--- a/src/components/DatePicker/tests/DatePicker.test.tsx
+++ b/src/components/DatePicker/tests/DatePicker.test.tsx
@@ -9,9 +9,8 @@ import {mockField, mountWithApp} from 'tests/utilities';
 import {CalendarMajor} from '@shopify/polaris-icons';
 
 import {DatePicker} from '../DatePicker';
-
-import {Weekday} from '~/constants';
-import {getDateTimeInShopTimeZone} from '~/utilities/dates';
+import {Weekday} from '../../../constants';
+import {getDateTimeInShopTimeZone} from '../../../utilities/dates';
 
 describe('<DatePicker />', () => {
   const mockDate = '2023-05-20';

--- a/src/components/DiscountCodeGenerator/DiscountCodeGenerator.tsx
+++ b/src/components/DiscountCodeGenerator/DiscountCodeGenerator.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import {Button, TextField} from '@shopify/polaris';
 import {useI18n} from '@shopify/react-i18n';
 
-import {generateRandomDiscountCode} from './utilities';
+import type {Field} from '../../types';
+import {DEFAULT_DISCOUNT_CODE_LENGTH} from '../../constants';
 
-import type {Field} from '~/types';
-import {DEFAULT_DISCOUNT_CODE_LENGTH} from '~/constants';
+import {generateRandomDiscountCode} from './utilities';
 
 export interface DiscountCodeGeneratorProps {
   /**

--- a/src/components/DiscountCodeGenerator/tests/utilities.test.ts
+++ b/src/components/DiscountCodeGenerator/tests/utilities.test.ts
@@ -1,6 +1,5 @@
 import {generateRandomDiscountCode} from '../utilities';
-
-import {DEFAULT_DISCOUNT_CODE_LENGTH} from '~/constants';
+import {DEFAULT_DISCOUNT_CODE_LENGTH} from '../../../constants';
 
 describe('discount code generator utilities', () => {
   describe('#generateRandomDiscountCode', () => {

--- a/src/components/DiscountCodeGenerator/utilities.ts
+++ b/src/components/DiscountCodeGenerator/utilities.ts
@@ -1,4 +1,4 @@
-import {DEFAULT_DISCOUNT_CODE_LENGTH} from '~/constants';
+import {DEFAULT_DISCOUNT_CODE_LENGTH} from '../../constants';
 
 const CHARS = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
 

--- a/src/components/MethodCard/MethodCard.tsx
+++ b/src/components/MethodCard/MethodCard.tsx
@@ -11,13 +11,12 @@ import {
 import {I18n, useI18n} from '@shopify/react-i18n';
 
 import {DiscountCodeGenerator} from '../DiscountCodeGenerator';
-
 import {
   DEFAULT_DISCOUNT_CODE_LENGTH,
   DiscountClass,
   DiscountMethod,
-} from '~/constants';
-import type {Field} from '~/types';
+} from '../../constants';
+import type {Field} from '../../types';
 
 const DISCOUNT_TITLE_MAX_LENGTH = 255;
 

--- a/src/components/MethodCard/tests/MethodCard.test.tsx
+++ b/src/components/MethodCard/tests/MethodCard.test.tsx
@@ -4,8 +4,7 @@ import {mockField, mountWithApp} from 'tests/utilities';
 
 import {MethodCard} from '../MethodCard';
 import {DiscountCodeGenerator} from '../../DiscountCodeGenerator';
-
-import {DiscountClass, DiscountMethod} from '~/constants';
+import {DiscountClass, DiscountMethod} from '../../../constants';
 
 describe('<MethodCard />', () => {
   const mockProps = {

--- a/src/components/MinimumRequirementsCard/MinimumRequirementsCard.tsx
+++ b/src/components/MinimumRequirementsCard/MinimumRequirementsCard.tsx
@@ -11,12 +11,11 @@ import {
 import {CurrencyCode, I18n, useI18n} from '@shopify/react-i18n';
 
 import {CurrencyField} from '../CurrencyField';
+import {forcePositiveInteger} from '../../utilities/numbers';
+import type {Field, PositiveNumericString} from '../../types';
+import {AppliesTo, DiscountMethod, RequirementType} from '../../constants';
 
 import styles from './MinimumRequirementsCard.scss';
-
-import {forcePositiveInteger} from '~/utilities/numbers';
-import type {Field, PositiveNumericString} from '~/types';
-import {AppliesTo, DiscountMethod, RequirementType} from '~/constants';
 
 export interface MinimumRequirementsCardProps {
   /**

--- a/src/components/MinimumRequirementsCard/tests/MinimumRequirementsCard.test.tsx
+++ b/src/components/MinimumRequirementsCard/tests/MinimumRequirementsCard.test.tsx
@@ -5,9 +5,8 @@ import {mockField, mountWithApp} from 'tests/utilities';
 
 import {MinimumRequirementsCard} from '../MinimumRequirementsCard';
 import {CurrencyField} from '../../CurrencyField';
-
-import {forcePositiveInteger} from '~/utilities/numbers';
-import {AppliesTo, DiscountMethod, RequirementType} from '~/constants';
+import {forcePositiveInteger} from '../../../utilities/numbers';
+import {AppliesTo, DiscountMethod, RequirementType} from '../../../constants';
 
 describe('<MinimumRequirementsCard>', () => {
   const mockProps = {

--- a/src/components/PurchaseTypeCard/PurchaseTypeCard.tsx
+++ b/src/components/PurchaseTypeCard/PurchaseTypeCard.tsx
@@ -3,8 +3,7 @@ import {ChoiceList, Card, Text, VerticalStack, Box} from '@shopify/polaris';
 import {useI18n} from '@shopify/react-i18n';
 
 import type {Field} from '../../types';
-
-import {PurchaseType} from '~/constants';
+import {PurchaseType} from '../../constants';
 
 export interface PurchaseTypeCardProps {
   /**

--- a/src/components/PurchaseTypeCard/tests/PurchaseTypeList.test.tsx
+++ b/src/components/PurchaseTypeCard/tests/PurchaseTypeList.test.tsx
@@ -3,8 +3,7 @@ import {Card, ChoiceList, Text} from '@shopify/polaris';
 import {mountWithApp, mockField} from 'tests/utilities';
 
 import {PurchaseTypeCard} from '../PurchaseTypeCard';
-
-import {PurchaseType} from '~/constants';
+import {PurchaseType} from '../../../constants';
 
 function mountWithProps({
   purchaseType = PurchaseType.OneTimePurchase,

--- a/src/components/SelectedItemsList/tests/SelectedItemsList.test.tsx
+++ b/src/components/SelectedItemsList/tests/SelectedItemsList.test.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 
 import {SelectedItemsList, Item} from '..';
-
-import type {Country} from '~/types';
+import type {Country} from '../../../types';
 
 describe('<SelectedItemsList />', () => {
   const mockProps = {

--- a/src/components/SummaryCard/components/ActiveDates/ActiveDates.tsx
+++ b/src/components/SummaryCard/components/ActiveDates/ActiveDates.tsx
@@ -3,7 +3,7 @@ import {I18n, useI18n} from '@shopify/react-i18n';
 import {List} from '@shopify/polaris';
 import {isToday, isSameDay} from '@shopify/dates';
 
-import type {DateTime} from '~/types';
+import type {DateTime} from '../../../../types';
 
 export interface ActiveDatesProps {
   /**

--- a/src/components/SummaryCard/components/AppliesToPurchaseType/AppliesToPurchaseType.tsx
+++ b/src/components/SummaryCard/components/AppliesToPurchaseType/AppliesToPurchaseType.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {List} from '@shopify/polaris';
 import {I18n, useI18n} from '@shopify/react-i18n';
 
-import {PurchaseType} from '~/constants';
+import {PurchaseType} from '../../../../constants';
 
 export interface AppliesToPurchaseTypeProps {
   /**

--- a/src/components/SummaryCard/components/AppliesToPurchaseType/tests/AppliesToPurchaseType.test.tsx
+++ b/src/components/SummaryCard/components/AppliesToPurchaseType/tests/AppliesToPurchaseType.test.tsx
@@ -3,8 +3,7 @@ import {List} from '@shopify/polaris';
 import {mountWithApp} from 'tests/utilities';
 
 import {AppliesToPurchaseType} from '../AppliesToPurchaseType';
-
-import {PurchaseType} from '~/constants';
+import {PurchaseType} from '../../../../../constants';
 
 describe('<AppliesToPurchaseType />', () => {
   it('renders when purchase type is PurchaseType.Both', () => {

--- a/src/components/SummaryCard/components/Combinations/Combinations.tsx
+++ b/src/components/SummaryCard/components/Combinations/Combinations.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import {List} from '@shopify/polaris';
 import {I18n, useI18n} from '@shopify/react-i18n';
 
-import {DiscountClass} from '~/constants';
-import type {CombinableDiscountTypes} from '~/types';
+import {DiscountClass} from '../../../../constants';
+import type {CombinableDiscountTypes} from '../../../../types';
 
 export interface CombinationsProps {
   /**

--- a/src/components/SummaryCard/components/CustomerEligibility/CustomerEligibility.tsx
+++ b/src/components/SummaryCard/components/CustomerEligibility/CustomerEligibility.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import {List} from '@shopify/polaris';
 import {useI18n} from '@shopify/react-i18n';
 
-import type {Customer, CustomerSegment} from '~/types';
-import {Eligibility} from '~/constants';
+import type {Customer, CustomerSegment} from '../../../../types';
+import {Eligibility} from '../../../../constants';
 
 const I18N_SCOPE = {
   scope: 'DiscountAppComponents.SummaryCard.CustomerEligibility',

--- a/src/components/SummaryCard/components/CustomerEligibility/tests/CustomerEligibility.test.tsx
+++ b/src/components/SummaryCard/components/CustomerEligibility/tests/CustomerEligibility.test.tsx
@@ -4,9 +4,8 @@ import {mountWithApp} from 'tests/utilities';
 import {List} from '@shopify/polaris';
 
 import {CustomerEligibility} from '../CustomerEligibility';
-
-import {Eligibility} from '~/constants';
-import type {Customer, CustomerSegment} from '~/types';
+import {Eligibility} from '../../../../../constants';
+import type {Customer, CustomerSegment} from '../../../../../types';
 
 describe('<CustomerEligibility />', () => {
   const mockProps = {

--- a/src/components/SummaryCard/components/Header/Header.tsx
+++ b/src/components/SummaryCard/components/Header/Header.tsx
@@ -8,7 +8,7 @@ import {
   VerticalStack,
 } from '@shopify/polaris';
 
-import {DiscountMethod, DiscountStatus} from '~/constants';
+import {DiscountMethod, DiscountStatus} from '../../../../constants';
 
 interface BaseProps {
   /**

--- a/src/components/SummaryCard/components/Header/tests/Header.test.tsx
+++ b/src/components/SummaryCard/components/Header/tests/Header.test.tsx
@@ -3,8 +3,7 @@ import {Badge} from '@shopify/polaris';
 import {mountWithApp} from 'tests/utilities';
 
 import {BadgeStatus, Header, HeaderProps} from '../Header';
-
-import {DiscountMethod, DiscountStatus} from '~/constants';
+import {DiscountMethod, DiscountStatus} from '../../../../../constants';
 
 describe('<Header />', () => {
   const mockProps: HeaderProps = {

--- a/src/components/SummaryCard/components/MaximumShippingPrice/MaximumShippingPrice.tsx
+++ b/src/components/SummaryCard/components/MaximumShippingPrice/MaximumShippingPrice.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {List} from '@shopify/polaris';
 import {CurrencyCode, useI18n} from '@shopify/react-i18n';
 
-import type {PositiveNumericString} from '~/types';
+import type {PositiveNumericString} from '../../../../types';
 
 export interface MaximumShippingPriceProps {
   /**

--- a/src/components/SummaryCard/components/MinimumRequirements/MinimumRequirements.tsx
+++ b/src/components/SummaryCard/components/MinimumRequirements/MinimumRequirements.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import {List} from '@shopify/polaris';
 import {I18n, useI18n, CurrencyCode} from '@shopify/react-i18n';
 
-import {RequirementType} from '~/constants';
-import type {PositiveNumericString} from '~/types';
+import {RequirementType} from '../../../../constants';
+import type {PositiveNumericString} from '../../../../types';
 
 export interface MinimumRequirementsProps {
   /**

--- a/src/components/SummaryCard/components/MinimumRequirements/tests/MinimumRequirements.test.tsx
+++ b/src/components/SummaryCard/components/MinimumRequirements/tests/MinimumRequirements.test.tsx
@@ -3,8 +3,7 @@ import {CurrencyCode} from '@shopify/react-i18n';
 import {mountWithApp} from 'tests/utilities';
 
 import {MinimumRequirements} from '../MinimumRequirements';
-
-import {RequirementType} from '~/constants';
+import {RequirementType} from '../../../../../constants';
 
 describe('<MinimumRequirements />', () => {
   const mockProps = {

--- a/src/components/SummaryCard/components/Performance/Performance.tsx
+++ b/src/components/SummaryCard/components/Performance/Performance.tsx
@@ -4,9 +4,8 @@ import {List, Text, VerticalStack} from '@shopify/polaris';
 import {Redirect} from '@shopify/app-bridge/actions';
 
 import {AppBridgeLink} from '../../../AppBridgeLink';
-
-import {DiscountMethod, DiscountStatus} from '~/constants';
-import type {MoneyInput} from '~/types';
+import {DiscountMethod, DiscountStatus} from '../../../../constants';
+import type {MoneyInput} from '../../../../types';
 
 export interface PerformanceProps {
   /**

--- a/src/components/SummaryCard/components/Performance/tests/Performance.test.tsx
+++ b/src/components/SummaryCard/components/Performance/tests/Performance.test.tsx
@@ -4,9 +4,8 @@ import {CurrencyCode} from '@shopify/react-i18n';
 import {Redirect} from '@shopify/app-bridge/actions';
 
 import {Performance} from '../Performance';
-
-import {DiscountMethod, DiscountStatus} from '~/constants';
-import {AppBridgeLink} from '~/components/AppBridgeLink';
+import {DiscountMethod, DiscountStatus} from '../../../../../constants';
+import {AppBridgeLink} from '../../../../AppBridgeLink';
 
 describe('<Performance />', () => {
   const mockProps = {

--- a/src/components/SummaryCard/components/RecurringPayment/RecurringPayment.tsx
+++ b/src/components/SummaryCard/components/RecurringPayment/RecurringPayment.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import {List} from '@shopify/polaris';
 import {useI18n} from '@shopify/react-i18n';
 
-import {RecurringPaymentType} from '~/constants';
-import type {PositiveNumericString} from '~/types';
+import {RecurringPaymentType} from '../../../../constants';
+import type {PositiveNumericString} from '../../../../types';
 
 export interface RecurringPaymentProps {
   /**

--- a/src/components/SummaryCard/components/RecurringPayment/tests/RecurringPayment.test.tsx
+++ b/src/components/SummaryCard/components/RecurringPayment/tests/RecurringPayment.test.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 
 import {RecurringPayment} from '../RecurringPayment';
-
-import {RecurringPaymentType} from '~/constants';
+import {RecurringPaymentType} from '../../../../../constants';
 
 describe('<RecurringPayment />', () => {
   const mockProps = {

--- a/src/components/SummaryCard/components/SelectedCountries/SelectedCountries.tsx
+++ b/src/components/SummaryCard/components/SelectedCountries/SelectedCountries.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import {List} from '@shopify/polaris';
 import {useI18n} from '@shopify/react-i18n';
 
-import {CountrySelectionType} from '~/constants';
-import type {CountryCode} from '~/types';
+import {CountrySelectionType} from '../../../../constants';
+import type {CountryCode} from '../../../../types';
 
 const I18N_SCOPE = {
   scope: 'DiscountAppComponents.SummaryCard.SelectedCountries',

--- a/src/components/SummaryCard/components/SelectedCountries/tests/SelectedCountries.test.tsx
+++ b/src/components/SummaryCard/components/SelectedCountries/tests/SelectedCountries.test.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 
 import {SelectedCountries} from '../SelectedCountries';
-
-import {CountrySelectionType, SupportedCountryCode} from '~/constants';
+import {
+  CountrySelectionType,
+  SupportedCountryCode,
+} from '../../../../../constants';
 
 const COUNTRIES = [
   SupportedCountryCode.Ca,

--- a/src/components/SummaryCard/components/UsageLimits/UsageLimits.tsx
+++ b/src/components/SummaryCard/components/UsageLimits/UsageLimits.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {List} from '@shopify/polaris';
 import {I18n, useI18n} from '@shopify/react-i18n';
 
-import type {PositiveNumericString} from '~/types';
+import type {PositiveNumericString} from '../../../../types';
 
 export interface UsageLimitsProps {
   /**

--- a/src/components/SummaryCard/tests/SummaryCard.test.tsx
+++ b/src/components/SummaryCard/tests/SummaryCard.test.tsx
@@ -17,7 +17,6 @@ import {
   CustomerEligibility,
   SelectedCountries,
 } from '../components';
-
 import {
   CountrySelectionType,
   DiscountMethod,
@@ -27,7 +26,7 @@ import {
   RecurringPaymentType,
   RequirementType,
   SupportedCountryCode,
-} from '~/constants';
+} from '../../../constants';
 
 describe('<SummaryCard />', () => {
   const mockProps: SummaryCardProps = {

--- a/src/components/TimePicker/TimePicker.tsx
+++ b/src/components/TimePicker/TimePicker.tsx
@@ -3,18 +3,18 @@ import {Autocomplete, Icon} from '@shopify/polaris';
 import {ClockMinor} from '@shopify/polaris-icons';
 import {useI18n} from '@shopify/react-i18n';
 
+import type {DateTime, Field} from '../../types';
+import {
+  getDateInShopTimeZone,
+  getDateTimeInShopTimeZone,
+} from '../../utilities/dates';
+
 import {
   formatDateListAsOptionList,
   generateTimes,
   getLocalizedTimeForDate,
   getValidDateForTime,
 } from './utilities';
-
-import type {DateTime, Field} from '~/types';
-import {
-  getDateInShopTimeZone,
-  getDateTimeInShopTimeZone,
-} from '~/utilities/dates';
 
 const TIME_BLOCKLIST_REGEX = /[^\d\s:apmAPM]/g;
 

--- a/src/components/TimePicker/utilities.ts
+++ b/src/components/TimePicker/utilities.ts
@@ -1,6 +1,6 @@
 import {applyTimeZoneOffset, formatDate, isSameDay} from '@shopify/dates';
 
-import {getBrowserAndShopTimeZoneOffset} from '~/utilities/dates';
+import {getBrowserAndShopTimeZoneOffset} from '../../utilities/dates';
 
 const TIME_INCREMENT = 30;
 const USER_INPUT_TIME_REGEX =

--- a/src/components/UsageLimitsCard/UsageLimitsCard.tsx
+++ b/src/components/UsageLimitsCard/UsageLimitsCard.tsx
@@ -10,12 +10,12 @@ import {
 } from '@shopify/polaris';
 import {useI18n} from '@shopify/react-i18n';
 
-import styles from './UsageLimitsCard.scss';
-import {RecurringPayment} from './components';
+import type {Field, PositiveNumericString} from '../../types';
+import type {RecurringPaymentType} from '../../constants';
+import {forcePositiveInteger} from '../../utilities/numbers';
 
-import type {Field, PositiveNumericString} from '~/types';
-import type {RecurringPaymentType} from '~/constants';
-import {forcePositiveInteger} from '~/utilities/numbers';
+import {RecurringPayment} from './components';
+import styles from './UsageLimitsCard.scss';
 
 export enum UsageLimitType {
   TotalUsageLimit = 'TOTAL_USAGE_LIMIT',

--- a/src/components/UsageLimitsCard/components/RecurringPayment/RecurringPayment.tsx
+++ b/src/components/UsageLimitsCard/components/RecurringPayment/RecurringPayment.tsx
@@ -8,11 +8,11 @@ import {
 } from '@shopify/polaris';
 import {useI18n} from '@shopify/react-i18n';
 
-import styles from './RecurringPayment.scss';
+import {RecurringPaymentType} from '../../../../constants';
+import type {Field, PositiveNumericString} from '../../../../types';
+import {forcePositiveInteger} from '../../../../utilities/numbers';
 
-import {RecurringPaymentType} from '~/constants';
-import type {Field, PositiveNumericString} from '~/types';
-import {forcePositiveInteger} from '~/utilities/numbers';
+import styles from './RecurringPayment.scss';
 
 const RECURRING_PAYMENT_FIELD_ID = 'RECURRING_PAYMENT_FIELD_ID';
 

--- a/src/components/UsageLimitsCard/components/RecurringPayment/tests/RecurringPayment.test.tsx
+++ b/src/components/UsageLimitsCard/components/RecurringPayment/tests/RecurringPayment.test.tsx
@@ -9,8 +9,7 @@ import {
 import {mockField, mountWithApp} from 'tests/utilities';
 
 import {RecurringPayment} from '../RecurringPayment';
-
-import {RecurringPaymentType} from '~/constants';
+import {RecurringPaymentType} from '../../../../../constants';
 
 const defaultProps = {
   recurringPaymentType: mockField(RecurringPaymentType.FirstPayment),

--- a/src/components/UsageLimitsCard/tests/UsageLimitsCard.test.tsx
+++ b/src/components/UsageLimitsCard/tests/UsageLimitsCard.test.tsx
@@ -15,9 +15,8 @@ import {
   UsageLimitType,
 } from '../UsageLimitsCard';
 import {RecurringPayment} from '../components';
-
-import {RecurringPaymentType} from '~/constants';
-import {forcePositiveInteger} from '~/utilities/numbers';
+import {RecurringPaymentType} from '../../../constants';
+import {forcePositiveInteger} from '../../../utilities/numbers';
 
 describe('UsageLimitsCard', () => {
   const defaultProps = {

--- a/src/components/ValueCard/ValueCard.tsx
+++ b/src/components/ValueCard/ValueCard.tsx
@@ -18,10 +18,9 @@ import {useI18n} from '@shopify/react-i18n';
 import {CurrencyField} from '../CurrencyField';
 import {DiscountValueType, DiscountClass, PurchaseType} from '../../constants';
 import {forcePositiveInteger} from '../../utilities/numbers';
+import type {Field} from '../../types';
 
 import styles from './ValueCard.scss';
-
-import type {Field} from '~/types';
 
 const FIXED_AMOUNT_VALUE_FIELD_ID = 'fixedAmountValueField';
 const PERCENTAGE_VALUE_FIELD_ID = 'percentageValueField';

--- a/src/stories/patterns/ValueCardPattern/ValueCardPattern.tsx
+++ b/src/stories/patterns/ValueCardPattern/ValueCardPattern.tsx
@@ -1,17 +1,26 @@
-import React, { useState } from "react"
-import { ValueCard } from "../../../components/ValueCard/ValueCard"
-import { DiscountClass, DiscountValueType, PurchaseType } from "~/constants";
-import { CurrencyCode } from "@shopify/react-i18n";
-import { Page } from "@shopify/polaris";
+import React, {useState} from 'react';
+import {ValueCard} from '../../../components/ValueCard/ValueCard';
+import {
+  DiscountClass,
+  DiscountValueType,
+  PurchaseType,
+} from '../../../constants';
+import {CurrencyCode} from '@shopify/react-i18n';
+import {Page} from '@shopify/polaris';
 
 const ValueCardPattern = () => {
-  const [fixedAmountDiscountValue, setFixedAmountDiscountValue] = useState('10');
+  const [fixedAmountDiscountValue, setFixedAmountDiscountValue] =
+    useState('10');
 
   const [percentageDiscountValue, setPercentageDiscountValue] = useState('20');
 
-  const [discountValueType, setDiscountValueType] = useState(DiscountValueType.Percentage);
+  const [discountValueType, setDiscountValueType] = useState(
+    DiscountValueType.Percentage,
+  );
 
-  const [purchaseType, setPurchaseType] = useState(PurchaseType.OneTimePurchase);
+  const [purchaseType, setPurchaseType] = useState(
+    PurchaseType.OneTimePurchase,
+  );
 
   const [oncePerOrder, setOncePerOrder] = useState(true);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,7 @@
     "paths": {
       "tests/*": ["./tests/*"],
       "@locales/*": ["./locales/*"],
-      "locales_dynamic/*": ["./locales/*"],
-      "~/*": ["./src/*"]
+      "locales_dynamic/*": ["./locales/*"]
     }
   },
   "include": ["./config/typescript", "./src", "./tests", "./styles.d.ts"]


### PR DESCRIPTION
### Description

Converted aliased paths to relative paths. 

This should fix: https://github.com/Shopify/discount-app-components/issues/51 

### How to

Used this codemod:

```js
const path = require('path');

const rootPath = path.resolve(__dirname, './src');

module.exports = function (fileInfo, api) {
  const j = api.jscodeshift;
  const root = j(fileInfo.source);

  return root
    .find(j.ImportDeclaration)
    .forEach((pathNode) => {
      const importPath = pathNode.node.source.value;
      if (importPath.startsWith('~/')) {
        const absolutePath = path.join(rootPath, importPath.slice(2));
        const relativePath = path.relative(
          path.dirname(fileInfo.path),
          absolutePath,
        );
        pathNode.node.source.value = relativePath;
      }
    })
    .toSource();
};
```

And ran it against TS/TSX/JS files: jscodeshift -t path-to-your-codemod.js --parser=tsx --extensions=ts,tsx src.

I also removed ~/ alias look ups and replacements in config files.

### Tophat 🎩 

Run storybook and make sure all stories are rendered properly. Run all tests. And CI passes.