### PR TITLE
chore: upgrade to polaris 12

### DIFF
--- a/.changeset/small-falcons-ring.md
+++ b/.changeset/small-falcons-ring.md
@@ -1,0 +1,5 @@
+---
+'@shopify/discount-app-components': major
+---
+
+Upgrade to Polaris 12

--- a/.changeset/small-falcons-ring.md
+++ b/.changeset/small-falcons-ring.md
@@ -2,4 +2,4 @@
 '@shopify/discount-app-components': major
 ---
 
-Upgrade to Polaris 12
+Upgrade to Polaris 12. See https://polaris.shopify.com/new-design-language to learn more about Polaris 12.

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@shopify/loom-plugin-eslint": "^2.0.0",
     "@shopify/loom-plugin-prettier": "^2.0.0",
     "@shopify/loom-plugin-stylelint": "^2.0.0",
-    "@shopify/polaris": "^11.19.0",
+    "@shopify/polaris": "^12.0.0-beta.0",
     "@shopify/postcss-plugin": "^5.0.1",
     "@shopify/prettier-config": "^1.1.2",
     "@shopify/react-testing": "^5.1.3",

--- a/src/components/AppProvider/AppProvider.tsx
+++ b/src/components/AppProvider/AppProvider.tsx
@@ -1,6 +1,5 @@
 import React, {useMemo} from 'react';
 import {I18nContext, I18nManager} from '@shopify/react-i18n';
-import {Frame} from '@shopify/polaris';
 
 import {DiscountsI18nProvider} from './components';
 
@@ -41,9 +40,7 @@ export function AppProvider(props: AppProviderProps) {
 
   return (
     <I18nContext.Provider value={i18nManager}>
-      <DiscountsI18nProvider>
-        <Frame>{props.children}</Frame>
-      </DiscountsI18nProvider>
+      <DiscountsI18nProvider>{props.children}</DiscountsI18nProvider>
     </I18nContext.Provider>
   );
 }

--- a/src/components/CustomerEligibilityCard/CustomerEligibilityCard.tsx
+++ b/src/components/CustomerEligibilityCard/CustomerEligibilityCard.tsx
@@ -80,6 +80,7 @@ export function CustomerEligibilityCard({
               eligibility.onChange(selectedEligibility[0]);
             }}
           />
+
           {eligibility.value === Eligibility.CustomerSegments && (
             <VerticalStack gap="4">
               {customerSegmentSelector}

--- a/src/components/DiscountCodeGenerator/DiscountCodeGenerator.tsx
+++ b/src/components/DiscountCodeGenerator/DiscountCodeGenerator.tsx
@@ -41,7 +41,7 @@ export function DiscountCodeGenerator({
       )}
       {...discountCode}
       connectedRight={
-        <Button onClick={handleGenerateDiscount}>
+        <Button onClick={handleGenerateDiscount} size="large">
           {i18n.translate(
             'DiscountAppComponents.DiscountCodeGenerator.buttonText',
           )}

--- a/src/components/ValueCard/ValueCard.tsx
+++ b/src/components/ValueCard/ValueCard.tsx
@@ -96,31 +96,31 @@ export function ValueCard({
             {i18n.translate('DiscountAppComponents.ValueCard.title')}{' '}
           </Text>
           <HorizontalStack gap="3" align="start">
-            <Box>
-              <ButtonGroup segmented>
-                <Button
-                  pressed={isPercentageDiscount}
-                  onClick={() =>
-                    discountValueType.onChange(DiscountValueType.Percentage)
-                  }
-                >
-                  {i18n.translate(
-                    'DiscountAppComponents.ValueCard.percentageButton',
-                  )}
-                </Button>
-                <Button
-                  pressed={!isPercentageDiscount}
-                  onClick={() =>
-                    discountValueType.onChange(DiscountValueType.FixedAmount)
-                  }
-                >
-                  {i18n.translate(
-                    'DiscountAppComponents.ValueCard.fixedAmountButton',
-                  )}
-                </Button>
-              </ButtonGroup>
-            </Box>
-            <Box>
+            <ButtonGroup segmented>
+              <Button
+                size="large"
+                pressed={isPercentageDiscount}
+                onClick={() =>
+                  discountValueType.onChange(DiscountValueType.Percentage)
+                }
+              >
+                {i18n.translate(
+                  'DiscountAppComponents.ValueCard.percentageButton',
+                )}
+              </Button>
+              <Button
+                size="large"
+                pressed={!isPercentageDiscount}
+                onClick={() =>
+                  discountValueType.onChange(DiscountValueType.FixedAmount)
+                }
+              >
+                {i18n.translate(
+                  'DiscountAppComponents.ValueCard.fixedAmountButton',
+                )}
+              </Button>
+            </ButtonGroup>
+            <Box width="75%">
               {!isPercentageDiscount && (
                 <CurrencyField
                   label={i18n.translate(

--- a/src/stories/patterns/CustomerEligibilityCardPattern/CustomerEligibilityCardPattern.tsx
+++ b/src/stories/patterns/CustomerEligibilityCardPattern/CustomerEligibilityCardPattern.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 
-import {Button, ChoiceList, HorizontalStack, Modal, Page} from '@shopify/polaris';
+import {Button, ChoiceList, Modal, Page} from '@shopify/polaris';
 import {
   Customer,
   CustomerEligibilityCard,
@@ -149,7 +149,7 @@ function CustomerModal({
 
   return (
     <Modal
-      activator={<HorizontalStack><Button onClick={toggleModal}>Browse</Button></HorizontalStack>}
+      activator={<Button onClick={toggleModal}>Browse</Button>}
       open={open}
       onClose={handleClose}
       title="Select customers"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2875,30 +2875,23 @@
     fs-extra "^9.0.0"
     glob "^7.1.6"
 
-"@shopify/polaris-icons@^7.1.0":
+"@shopify/polaris-icons@^7.1.0", "@shopify/polaris-icons@^7.7.0":
   version "7.8.1"
   resolved "https://registry.yarnpkg.com/@shopify/polaris-icons/-/polaris-icons-7.8.1.tgz#06f304a9cee40a414e87278ebc3eabb180006bcf"
   integrity sha512-3qg3tzLEzeKzAcVcswNtdAoY+YNk0zq7Q0BUYzCQrr8InJqxMTrbihbVVxJ9209onfh/eosMacmzM2CHx3xjeQ==
 
-"@shopify/polaris-icons@^7.9.0":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris-icons/-/polaris-icons-7.9.0.tgz#2c7ec5b5cf2d68c6252bf9992c4604a2def596c3"
-  integrity sha512-JSn8tg5c6cWiKqOJE1757kuK8JKP9NGpwIp9Li2gEIA/PP4LL8RHMYOIuH3RS/yQO3pEhVsHnnlVFvREate8ng==
+"@shopify/polaris-tokens@^7.5.2":
+  version "7.5.2"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris-tokens/-/polaris-tokens-7.5.2.tgz#6ab5308dfdcf912e01e60b659060bd10678b7b91"
+  integrity sha512-xEpIhwqR1RHVjY4YGeZd4In8NrjE5IHunyvXtbXrZZ75ydCqP7GYIhC8JSB8OyEx9eb4R4ERRgLyhYnDLG0TYA==
 
-"@shopify/polaris-tokens@^7.9.0":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris-tokens/-/polaris-tokens-7.9.0.tgz#14b994dcc594ee9aee6c95f31ff30d0344bdedc5"
-  integrity sha512-6brDZWIp5FJVD84Z0mkFZkzY14xTWBsr5yvchTrUNFQeoQHCHrkQoelpC6frBLbrtlf0yiQbYvmHvTtgLh1+DA==
+"@shopify/polaris@^12.0.0-beta.0":
+  version "12.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris/-/polaris-12.0.0-beta.0.tgz#274ab7313f862c35597f9588a48c93458c8a720e"
+  integrity sha512-/AZKs9GWPLfoxQw65bU8svohC3bi0CIDyU+6jGwciS5iJB5yU07XumNkuk6adKqRcaxFallN+j2tTNSbw+LG7g==
   dependencies:
-    deepmerge "^4.3.1"
-
-"@shopify/polaris@^11.19.0":
-  version "11.19.0"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris/-/polaris-11.19.0.tgz#4881d8ebfa69fb804bcb81c23b1fb794a3af9a4b"
-  integrity sha512-sEXTptk0vMiZtxZX46/9OVEYt2Fzrra/66MYwjt9k5pQHTob3kBDDrqcADOzdAJvBCGEuBmHM54LL8ghJ4YGZA==
-  dependencies:
-    "@shopify/polaris-icons" "^7.9.0"
-    "@shopify/polaris-tokens" "^7.9.0"
+    "@shopify/polaris-icons" "^7.7.0"
+    "@shopify/polaris-tokens" "^7.5.2"
     "@types/react" "^18.2.0"
     "@types/react-dom" "^18.2.0"
     "@types/react-transition-group" "^4.4.2"
@@ -6590,7 +6583,7 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
-deepmerge@^4.2.2, deepmerge@^4.3.1:
+deepmerge@^4.2.2:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
   integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==


### PR DESCRIPTION
### What problem is this PR solving?

This PR upgrades Polaris to v12. Releasing this as a major version so that npm doesn't pick it up in consuming repos. Developers who consume this library can upgrade manually when ready.


### Definition of `^` &  `~` 

- `^1.2.3` : allows changes that do not modify the left-most non-zero digit in the version, or do not increment the major version number. This allows patch and minor updates for versions 1.x.x.
- `~1.2.3` : allows patch-level changes for a minor version, i.e., it allows versions up to 1.2.x, but not 1.3.0.
- `1.2.3` : allows only that specific version.



### Reviewers’ hat-rack :tophat:

Storybook should work as expected and all tests should pass.

### Before you deploy

> **Warning**
> With every PR, you **MUST** think through each of the items in the following checklist and check the appropriate ones. This step cannot be overlooked by the **PR author** or its **reviewers**. Please remove this warning when you're done.

- [x] This PR is safe to rollback.
- [x] I tophatted this change on Storybook.
