### PR TITLE
Chore: Update Polaris 12 beta-1

### DIFF
--- a/.changeset/tidy-eagles-tickle.md
+++ b/.changeset/tidy-eagles-tickle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/discount-app-components': minor
+---
+
+Update Polaris to beta-1

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@shopify/loom-plugin-eslint": "^2.0.0",
     "@shopify/loom-plugin-prettier": "^2.0.0",
     "@shopify/loom-plugin-stylelint": "^2.0.0",
-    "@shopify/polaris": "^12.0.0-beta.0",
+    "@shopify/polaris": "^12.0.0-beta.1",
     "@shopify/postcss-plugin": "^5.0.1",
     "@shopify/prettier-config": "^1.1.2",
     "@shopify/react-testing": "^5.1.3",

--- a/src/components/AppliesTo/AppliesTo.tsx
+++ b/src/components/AppliesTo/AppliesTo.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect} from 'react';
-import {ChoiceList, VerticalStack, Text, Box} from '@shopify/polaris';
+import {ChoiceList, BlockStack, Text, Box} from '@shopify/polaris';
 import {useI18n} from '@shopify/react-i18n';
 
 import {SelectedItemsList} from '../SelectedItemsList';
@@ -36,7 +36,7 @@ export function AppliesTo({
     <>
       {productSelector || collectionSelector ? (
         <Box paddingBlockEnd="4">
-          <VerticalStack gap="4">
+          <BlockStack gap="4">
             <Text variant="headingMd" as="h2">
               {i18n.translate('DiscountAppComponents.AppliesToCard.title')}
             </Text>
@@ -102,7 +102,7 @@ export function AppliesTo({
                 />
               </>
             )}
-          </VerticalStack>
+          </BlockStack>
         </Box>
       ) : null}
     </>

--- a/src/components/CombinationCard/CombinationCard.tsx
+++ b/src/components/CombinationCard/CombinationCard.tsx
@@ -4,7 +4,7 @@ import {
   Link,
   Card,
   ChoiceList,
-  VerticalStack,
+  BlockStack,
   Text,
   ChoiceListProps,
   Box,
@@ -82,7 +82,7 @@ export function CombinationCard({
   return (
     <Box paddingBlockEnd="4">
       <Card padding="4">
-        <VerticalStack gap="4">
+        <BlockStack gap="4">
           <Text variant="headingMd" as="h2">
             {i18n.translate('title', I18N_SCOPE)}
           </Text>
@@ -133,7 +133,7 @@ export function CombinationCard({
             selected={getSelectedChoices(combinableDiscountTypes.value)}
             onChange={handleDiscountCombinesWithChange}
           />
-        </VerticalStack>
+        </BlockStack>
       </Card>
     </Box>
   );

--- a/src/components/CombinationCard/CombinationCard.tsx
+++ b/src/components/CombinationCard/CombinationCard.tsx
@@ -89,7 +89,7 @@ export function CombinationCard({
           {shouldShowBanner && (
             <Banner
               title={i18n.translate('warning.title', I18N_SCOPE)}
-              status="warning"
+              tone="warning"
             >
               <p>
                 {i18n.translate('warning.description', I18N_SCOPE)}{' '}

--- a/src/components/CombinationCard/components/HelpText/HelpText.tsx
+++ b/src/components/CombinationCard/components/HelpText/HelpText.tsx
@@ -64,7 +64,7 @@ export function HelpText({
             count,
             discountCountLink: (
               <span ref={buttonWrapperRef}>
-                <Button onClick={handleModalOpen} plain>
+                <Button onClick={handleModalOpen} variant='plain'>
                   {i18n.translate(
                     `combinations.counts.${targetDiscountClassLabel}`,
                     {scope},

--- a/src/components/CombinationCard/components/HelpText/HelpText.tsx
+++ b/src/components/CombinationCard/components/HelpText/HelpText.tsx
@@ -1,5 +1,5 @@
 import React, {useRef} from 'react';
-import {Button, Text, Link, VerticalStack} from '@shopify/polaris';
+import {Button, Text, Link, BlockStack} from '@shopify/polaris';
 import {useI18n} from '@shopify/react-i18n';
 import {useAppBridge} from '@shopify/app-bridge-react';
 import {Modal} from '@shopify/app-bridge/actions';
@@ -55,7 +55,7 @@ export function HelpText({
   };
 
   return count > 0 ? (
-    <VerticalStack>
+    <BlockStack>
       <Text as="span" color="subdued">
         {i18n.translate(
           'combinations.info',
@@ -81,7 +81,7 @@ export function HelpText({
       <Text as="span" color="subdued">
         {i18n.translate('combinations.multipleEligibleDiscounts', {scope})}
       </Text>
-    </VerticalStack>
+    </BlockStack>
   ) : (
     <>
       <Text as="span" color="subdued">

--- a/src/components/CombinationCard/components/HelpText/HelpText.tsx
+++ b/src/components/CombinationCard/components/HelpText/HelpText.tsx
@@ -56,7 +56,7 @@ export function HelpText({
 
   return count > 0 ? (
     <BlockStack>
-      <Text as="span" color="subdued">
+      <Text as="span" tone="subdued">
         {i18n.translate(
           'combinations.info',
           {scope},
@@ -78,13 +78,13 @@ export function HelpText({
           },
         )}
       </Text>
-      <Text as="span" color="subdued">
+      <Text as="span" tone="subdued">
         {i18n.translate('combinations.multipleEligibleDiscounts', {scope})}
       </Text>
     </BlockStack>
   ) : (
     <>
-      <Text as="span" color="subdued">
+      <Text as="span" tone="subdued">
         {i18n.translate('title', {
           scope: `${scope}.emptyState.${targetDiscountClass.toLowerCase()}`,
         })}{' '}

--- a/src/components/CombinationCard/components/HelpText/tests/HelpText.test.tsx
+++ b/src/components/CombinationCard/components/HelpText/tests/HelpText.test.tsx
@@ -96,7 +96,7 @@ describe('<HelpText />', () => {
       expect(helpText).toContainReactComponent(Button, {
         children: `2 product discounts`,
         onClick: expect.any(Function),
-        plain: true,
+        variant: 'plain',
       });
     });
 

--- a/src/components/CountriesAndRatesCard/CountriesAndRatesCard.tsx
+++ b/src/components/CountriesAndRatesCard/CountriesAndRatesCard.tsx
@@ -4,7 +4,7 @@ import {
   ChoiceList,
   Checkbox,
   InlineError,
-  VerticalStack,
+  BlockStack,
   Text,
   Box,
 } from '@shopify/polaris';
@@ -71,7 +71,7 @@ export function CountriesAndRatesCard({
   return (
     <Box paddingBlockEnd="4">
       <Card padding="4">
-        <VerticalStack gap="4">
+        <BlockStack gap="4">
           <Text variant="headingMd" as="h2">
             {i18n.translate(
               'DiscountAppComponents.CountriesAndRatesCard.title',
@@ -158,7 +158,7 @@ export function CountriesAndRatesCard({
             </>
           )}
           {/* </Card.Section> */}
-        </VerticalStack>
+        </BlockStack>
       </Card>
     </Box>
   );

--- a/src/components/CurrencyField/CurrencyField.tsx
+++ b/src/components/CurrencyField/CurrencyField.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {useI18n, CurrencyCode, I18n} from '@shopify/react-i18n';
-import {HorizontalStack} from '@shopify/polaris';
+import {InlineStack} from '@shopify/polaris';
 
 import {
   FormattedNumberField,
@@ -94,10 +94,10 @@ function renderSuffix(
 
   if (appendSuffixToCurrency && !prefixed && suffix) {
     return (
-      <HorizontalStack align="center">
+      <InlineStack align="center">
         <div>{symbol}</div>
         <div>{suffix}</div>
-      </HorizontalStack>
+      </InlineStack>
     );
   }
 

--- a/src/components/CustomerEligibilityCard/CustomerEligibilityCard.tsx
+++ b/src/components/CustomerEligibilityCard/CustomerEligibilityCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Box, Card, ChoiceList, Text, VerticalStack} from '@shopify/polaris';
+import {Box, Card, ChoiceList, Text, BlockStack} from '@shopify/polaris';
 import {useI18n} from '@shopify/react-i18n';
 import {Action} from '@shopify/app-bridge/actions/Navigation/Redirect';
 import {parseGid} from '@shopify/admin-graphql-api-utilities';
@@ -54,7 +54,7 @@ export function CustomerEligibilityCard({
   return (
     <Box paddingBlockEnd="4">
       <Card padding="4">
-        <VerticalStack gap="4">
+        <BlockStack gap="4">
           <Text variant="headingMd" as="h2">
             {i18n.translate('title', I18N_SCOPE)}
           </Text>
@@ -82,22 +82,22 @@ export function CustomerEligibilityCard({
           />
 
           {eligibility.value === Eligibility.CustomerSegments && (
-            <VerticalStack gap="4">
+            <BlockStack gap="4">
               {customerSegmentSelector}
 
               <SelectedCustomerSegmentsList
                 selectedCustomerSegments={selectedCustomerSegments}
               />
-            </VerticalStack>
+            </BlockStack>
           )}
 
           {eligibility.value === Eligibility.Customers && (
-            <VerticalStack gap="4">
+            <BlockStack gap="4">
               {customerSelector}
               <SelectedCustomersList selectedCustomers={selectedCustomers} />
-            </VerticalStack>
+            </BlockStack>
           )}
-        </VerticalStack>
+        </BlockStack>
       </Card>
     </Box>
   );

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -177,7 +177,7 @@ export function DatePicker({
           value={userInput}
           label={label}
           labelHidden={labelHidden}
-          prefix={<Icon source={CalendarMajor} color="subdued" />}
+          prefix={<Icon source={CalendarMajor} tone="subdued" />}
           placeholder={i18n.translate(
             'DiscountAppComponents.DatePicker.datePlaceholder',
           )}

--- a/src/components/DatePicker/tests/DatePicker.test.tsx
+++ b/src/components/DatePicker/tests/DatePicker.test.tsx
@@ -53,7 +53,7 @@ describe('<DatePicker />', () => {
 
       expect(datePicker.find(TextField)).toContainReactComponent(Icon, {
         source: CalendarMajor,
-        color: 'subdued',
+        tone: 'subdued',
       });
     });
 

--- a/src/components/DiscountApplicationStrategyCard/DiscountApplicationStrategyCard.tsx
+++ b/src/components/DiscountApplicationStrategyCard/DiscountApplicationStrategyCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Box, Card, ChoiceList, Text, VerticalStack} from '@shopify/polaris';
+import {Box, Card, ChoiceList, Text, BlockStack} from '@shopify/polaris';
 import {useI18n} from '@shopify/react-i18n';
 
 import {DiscountApplicationStrategy, Field} from '../../types';
@@ -26,7 +26,7 @@ export function DiscountApplicationStrategyCard({
   return (
     <Box paddingBlockEnd="4">
       <Card padding="4">
-        <VerticalStack gap="4">
+        <BlockStack gap="4">
           <Text variant="headingMd" as="h2">
             {i18n.translate('title', I18N_SCOPE)}
           </Text>
@@ -48,7 +48,7 @@ export function DiscountApplicationStrategyCard({
             selected={[strategy.value]}
             onChange={handleChange}
           />
-        </VerticalStack>
+        </BlockStack>
       </Card>
     </Box>
   );

--- a/src/components/MethodCard/MethodCard.tsx
+++ b/src/components/MethodCard/MethodCard.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import {
   Card,
   ChoiceList,
-  VerticalStack,
+  BlockStack,
   TextField,
   Text,
-  HorizontalStack,
+  InlineStack,
   Box,
 } from '@shopify/polaris';
 import {I18n, useI18n} from '@shopify/react-i18n';
@@ -76,15 +76,15 @@ export function MethodCard({
   return (
     <Box paddingBlockEnd="4">
       <Card padding="4">
-        <VerticalStack gap="4">
-          <HorizontalStack align="start" blockAlign="center" gap="1">
+        <BlockStack gap="4">
+          <InlineStack align="start" blockAlign="center" gap="1">
             <Text variant="headingMd" as="h2">
               {title}
             </Text>
             <Text as="span" color="subdued">
               {getDiscountClassLabel(discountClass, i18n)}
             </Text>
-          </HorizontalStack>
+          </InlineStack>
 
           {!discountMethodHidden && (
             <Text variant="headingMd" as="h2">
@@ -93,7 +93,7 @@ export function MethodCard({
               )}
             </Text>
           )}
-          <VerticalStack gap="4">
+          <BlockStack gap="4">
             {!discountMethodHidden && (
               <ChoiceList
                 title={i18n.translate(
@@ -136,8 +136,8 @@ export function MethodCard({
                 {...discountTitle}
               />
             )}
-          </VerticalStack>
-        </VerticalStack>
+          </BlockStack>
+        </BlockStack>
       </Card>
     </Box>
   );

--- a/src/components/MethodCard/MethodCard.tsx
+++ b/src/components/MethodCard/MethodCard.tsx
@@ -81,7 +81,7 @@ export function MethodCard({
             <Text variant="headingMd" as="h2">
               {title}
             </Text>
-            <Text as="span" color="subdued">
+            <Text as="span" tone="subdued">
               {getDiscountClassLabel(discountClass, i18n)}
             </Text>
           </InlineStack>

--- a/src/components/MethodCard/tests/MethodCard.test.tsx
+++ b/src/components/MethodCard/tests/MethodCard.test.tsx
@@ -4,7 +4,7 @@ import {
   ChoiceList,
   Text,
   TextField,
-  HorizontalStack,
+  InlineStack,
 } from '@shopify/polaris';
 import {mockField, mountWithApp} from 'tests/utilities';
 
@@ -52,7 +52,7 @@ describe('<MethodCard />', () => {
     expect(methodCard).toContainReactComponent(Card, {
       padding: '4',
     });
-    expect(methodCard).toContainReactComponent(HorizontalStack, {
+    expect(methodCard).toContainReactComponent(InlineStack, {
       align: 'start',
       blockAlign: 'center',
       gap: '1',

--- a/src/components/MinimumRequirementsCard/MinimumRequirementsCard.tsx
+++ b/src/components/MinimumRequirementsCard/MinimumRequirementsCard.tsx
@@ -102,7 +102,7 @@ export function MinimumRequirementsCard({
   );
 
   const fieldHelpTextMarkup = (
-    <Text as="span" color="subdued">
+    <Text as="span" tone="subdued">
       {getFieldHelpText(isRecurring, appliesTo, i18n)}
     </Text>
   );

--- a/src/components/MinimumRequirementsCard/MinimumRequirementsCard.tsx
+++ b/src/components/MinimumRequirementsCard/MinimumRequirementsCard.tsx
@@ -5,7 +5,7 @@ import {
   ChoiceList,
   InlineError,
   Text,
-  VerticalStack,
+  BlockStack,
   Box,
 } from '@shopify/polaris';
 import {CurrencyCode, I18n, useI18n} from '@shopify/react-i18n';
@@ -120,7 +120,7 @@ export function MinimumRequirementsCard({
       renderChildren: (isSelected: boolean) => {
         return (
           isSelected && (
-            <VerticalStack gap="4">
+            <BlockStack gap="4">
               <div className={styles.TextField}>
                 <CurrencyField
                   id={SUBTOTAL_FIELD_ID}
@@ -142,7 +142,7 @@ export function MinimumRequirementsCard({
                   message={subtotal.error}
                 />
               )}
-            </VerticalStack>
+            </BlockStack>
           )
         );
       },
@@ -153,7 +153,7 @@ export function MinimumRequirementsCard({
       renderChildren: (isSelected: boolean) => {
         return (
           isSelected && (
-            <VerticalStack gap="4">
+            <BlockStack gap="4">
               <div className={styles.TextField}>
                 <TextField
                   id={QUANTITY_FIELD_ID}
@@ -176,7 +176,7 @@ export function MinimumRequirementsCard({
                   message={quantity.error}
                 />
               )}
-            </VerticalStack>
+            </BlockStack>
           )
         );
       },
@@ -193,7 +193,7 @@ export function MinimumRequirementsCard({
   return (
     <Box paddingBlockEnd="4">
       <Card padding="4">
-        <VerticalStack gap="4">
+        <BlockStack gap="4">
           <Text variant="headingMd" as="h2">
             {i18n.translate(
               'DiscountAppComponents.MinimumRequirementsCard.title',
@@ -210,7 +210,7 @@ export function MinimumRequirementsCard({
               requirementType.onChange(nextValue[0])
             }
           />
-        </VerticalStack>
+        </BlockStack>
       </Card>
     </Box>
   );

--- a/src/components/PurchaseTypeCard/PurchaseTypeCard.tsx
+++ b/src/components/PurchaseTypeCard/PurchaseTypeCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {ChoiceList, Card, Text, VerticalStack, Box} from '@shopify/polaris';
+import {ChoiceList, Card, Text, BlockStack, Box} from '@shopify/polaris';
 import {useI18n} from '@shopify/react-i18n';
 
 import type {Field} from '../../types';
@@ -17,7 +17,7 @@ export function PurchaseTypeCard({purchaseType}: PurchaseTypeCardProps) {
   return (
     <Box paddingBlockEnd="4">
       <Card padding="4">
-        <VerticalStack gap="4">
+        <BlockStack gap="4">
           <Text variant="headingMd" as="h2">
             {i18n.translate('DiscountAppComponents.PurchaseTypeList.title')}
           </Text>
@@ -51,7 +51,7 @@ export function PurchaseTypeCard({purchaseType}: PurchaseTypeCardProps) {
               purchaseType.onChange(purchaseTypeList[0] as PurchaseType);
             }}
           />
-        </VerticalStack>
+        </BlockStack>
       </Card>
     </Box>
   );

--- a/src/components/SelectedItemsList/components/Item/Item.tsx
+++ b/src/components/SelectedItemsList/components/Item/Item.tsx
@@ -15,7 +15,7 @@ export function Item({children, onRemove}: Props) {
       <div className={styles.Content}>{children}</div>
       {onRemove && (
         <div className={styles.Actions}>
-          <Button icon={CancelSmallMinor} plain onClick={() => onRemove()} />
+          <Button icon={CancelSmallMinor} variant='plain' onClick={() => onRemove()} />
         </div>
       )}
     </li>

--- a/src/components/SummaryCard/SummaryCard.tsx
+++ b/src/components/SummaryCard/SummaryCard.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @shopify/typescript/prefer-pascal-case-enums */
 import React from 'react';
 import {useI18n} from '@shopify/react-i18n';
-import {List, Card, VerticalStack, Text, Box} from '@shopify/polaris';
+import {List, Card, BlockStack, Text, Box} from '@shopify/polaris';
 
 import {
   ActiveDates,
@@ -117,16 +117,16 @@ export function SummaryCard(props: SummaryCardProps) {
   return (
     <Box paddingBlockEnd="4">
       <Card padding="4">
-        <VerticalStack gap="4">
+        <BlockStack gap="4">
           <Text variant="headingMd" as="h2">
             {i18n.translate('title', I18N_SCOPE)}
           </Text>
 
-          <VerticalStack gap="2">
+          <BlockStack gap="2">
             <Header {...props.header} />
 
             {showDetailsSection && (
-              <VerticalStack gap="2">
+              <BlockStack gap="2">
                 <Text variant="headingXs" as="h3">
                   {i18n.translate('details', I18N_SCOPE)}
                 </Text>
@@ -170,11 +170,11 @@ export function SummaryCard(props: SummaryCardProps) {
 
                   {props.activeDates && <ActiveDates {...props.activeDates} />}
                 </List>
-              </VerticalStack>
+              </BlockStack>
             )}
-          </VerticalStack>
+          </BlockStack>
           <Performance {...props.performance} />
-        </VerticalStack>
+        </BlockStack>
       </Card>
     </Box>
   );

--- a/src/components/SummaryCard/components/Header/Header.tsx
+++ b/src/components/SummaryCard/components/Header/Header.tsx
@@ -72,7 +72,7 @@ export function Header(props: HeaderProps) {
           {isEditing(props) && renderBadgeForStatus(props.discountStatus, i18n)}
         </InlineStack>
       ) : (
-        <Text as="span" fontWeight="semibold" color="subdued">
+        <Text as="span" fontWeight="semibold" tone="subdued">
           {i18n.translate(`emptyState.${discountMethod}`, I18N_SCOPE)}
         </Text>
       )}
@@ -96,7 +96,7 @@ function renderBadgeForStatus(status: DiscountStatus, i18n: I18n) {
   switch (status) {
     case DiscountStatus.Active:
       return (
-        <Badge status={BadgeStatus.Success}>
+        <Badge tone={BadgeStatus.Success}>
           {i18n.translate('badge.active', I18N_SCOPE)}
         </Badge>
       );
@@ -104,7 +104,7 @@ function renderBadgeForStatus(status: DiscountStatus, i18n: I18n) {
       return <Badge>{i18n.translate('badge.expired', I18N_SCOPE)}</Badge>;
     case DiscountStatus.Scheduled:
       return (
-        <Badge status={BadgeStatus.Attention}>
+        <Badge tone={BadgeStatus.Attention}>
           {i18n.translate('badge.scheduled', I18N_SCOPE)}
         </Badge>
       );

--- a/src/components/SummaryCard/components/Header/Header.tsx
+++ b/src/components/SummaryCard/components/Header/Header.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import {I18n, useI18n} from '@shopify/react-i18n';
 import {
   Badge,
-  HorizontalStack,
+  InlineStack,
   List,
   Text,
-  VerticalStack,
+  BlockStack,
 } from '@shopify/polaris';
 
 import {DiscountMethod, DiscountStatus} from '../../../../constants';
@@ -62,22 +62,22 @@ export function Header(props: HeaderProps) {
   const trimmedDescriptor = discountDescriptor.trim();
 
   return (
-    <VerticalStack gap="4">
+    <BlockStack gap="4">
       {trimmedDescriptor ? (
-        <HorizontalStack align="space-between">
+        <InlineStack align="space-between">
           <Text variant="headingMd" as="h3">
             {trimmedDescriptor}
           </Text>
 
           {isEditing(props) && renderBadgeForStatus(props.discountStatus, i18n)}
-        </HorizontalStack>
+        </InlineStack>
       ) : (
         <Text as="span" fontWeight="semibold" color="subdued">
           {i18n.translate(`emptyState.${discountMethod}`, I18N_SCOPE)}
         </Text>
       )}
 
-      <VerticalStack gap="2">
+      <BlockStack gap="2">
         <Text variant="headingXs" as="h3">
           {i18n.translate('typeAndMethod', I18N_SCOPE)}
         </Text>
@@ -87,8 +87,8 @@ export function Header(props: HeaderProps) {
             {i18n.translate(`discountMethod.${discountMethod}`, I18N_SCOPE)}
           </List.Item>
         </List>
-      </VerticalStack>
-    </VerticalStack>
+      </BlockStack>
+    </BlockStack>
   );
 }
 

--- a/src/components/SummaryCard/components/Header/tests/Header.test.tsx
+++ b/src/components/SummaryCard/components/Header/tests/Header.test.tsx
@@ -29,12 +29,12 @@ describe('<Header />', () => {
           {...mockProps}
           discountDescriptor="SPRING_SALE"
           isEditing
-          discounttone={DiscountStatus.Active}
+          discountStatus={DiscountStatus.Active}
         />,
       );
 
       expect(header).toContainReactComponent(Badge, {
-        status: BadgeStatus.Success,
+        tone: BadgeStatus.Success,
         children: 'Active',
       });
     });
@@ -45,7 +45,7 @@ describe('<Header />', () => {
           {...mockProps}
           discountDescriptor="SPRING_SALE"
           isEditing
-          discounttone={DiscountStatus.Expired}
+          discountStatus={DiscountStatus.Expired}
         />,
       );
 
@@ -60,12 +60,12 @@ describe('<Header />', () => {
           {...mockProps}
           discountDescriptor="SPRING_SALE"
           isEditing
-          discounttone={DiscountStatus.Scheduled}
+          discountStatus={DiscountStatus.Scheduled}
         />,
       );
 
       expect(header).toContainReactComponent(Badge, {
-        status: BadgeStatus.Attention,
+        tone: BadgeStatus.Attention,
         children: 'Scheduled',
       });
     });

--- a/src/components/SummaryCard/components/Header/tests/Header.test.tsx
+++ b/src/components/SummaryCard/components/Header/tests/Header.test.tsx
@@ -29,7 +29,7 @@ describe('<Header />', () => {
           {...mockProps}
           discountDescriptor="SPRING_SALE"
           isEditing
-          discountStatus={DiscountStatus.Active}
+          discounttone={DiscountStatus.Active}
         />,
       );
 
@@ -45,7 +45,7 @@ describe('<Header />', () => {
           {...mockProps}
           discountDescriptor="SPRING_SALE"
           isEditing
-          discountStatus={DiscountStatus.Expired}
+          discounttone={DiscountStatus.Expired}
         />,
       );
 
@@ -60,7 +60,7 @@ describe('<Header />', () => {
           {...mockProps}
           discountDescriptor="SPRING_SALE"
           isEditing
-          discountStatus={DiscountStatus.Scheduled}
+          discounttone={DiscountStatus.Scheduled}
         />,
       );
 

--- a/src/components/SummaryCard/components/Performance/Performance.tsx
+++ b/src/components/SummaryCard/components/Performance/Performance.tsx
@@ -58,7 +58,7 @@ export function Performance({
         {i18n.translate('title', I18N_SCOPE)}
       </Text>
       {status === DiscountStatus.Scheduled && (
-        <Text as="span" color="subdued">
+        <Text as="span" tone="subdued">
           {i18n.translate('notActive', I18N_SCOPE)}
         </Text>
       )}

--- a/src/components/SummaryCard/components/Performance/Performance.tsx
+++ b/src/components/SummaryCard/components/Performance/Performance.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {useI18n} from '@shopify/react-i18n';
-import {List, Text, VerticalStack} from '@shopify/polaris';
+import {List, Text, BlockStack} from '@shopify/polaris';
 import {Redirect} from '@shopify/app-bridge/actions';
 
 import {AppBridgeLink} from '../../../AppBridgeLink';
@@ -53,7 +53,7 @@ export function Performance({
     status === DiscountStatus.Active || status === DiscountStatus.Expired;
 
   return (
-    <VerticalStack gap="2">
+    <BlockStack gap="2">
       <Text variant="headingXs" as="h3">
         {i18n.translate('title', I18N_SCOPE)}
       </Text>
@@ -90,6 +90,6 @@ export function Performance({
           )}
         </>
       )}
-    </VerticalStack>
+    </BlockStack>
   );
 }

--- a/src/components/SummaryCard/components/Performance/tests/Performance.test.tsx
+++ b/src/components/SummaryCard/components/Performance/tests/Performance.test.tsx
@@ -17,7 +17,7 @@ describe('<Performance />', () => {
   describe('when discount is scheduled', () => {
     it('renders copy for inactive discount', () => {
       const performance = mountWithApp(
-        <Performance {...mockProps} status={DiscountStatus.Scheduled} />,
+        <Performance {...mockProps} tone={DiscountStatus.Scheduled} />,
       );
 
       expect(performance).toContainReactText('Discount is not active yet.');
@@ -32,7 +32,7 @@ describe('<Performance />', () => {
         const performance = mountWithApp(
           <Performance
             {...mockProps}
-            status={status}
+            tone={status}
             usageCount={usageCount}
           />,
         );

--- a/src/components/SummaryCard/components/Performance/tests/Performance.test.tsx
+++ b/src/components/SummaryCard/components/Performance/tests/Performance.test.tsx
@@ -17,7 +17,7 @@ describe('<Performance />', () => {
   describe('when discount is scheduled', () => {
     it('renders copy for inactive discount', () => {
       const performance = mountWithApp(
-        <Performance {...mockProps} tone={DiscountStatus.Scheduled} />,
+        <Performance {...mockProps} status={DiscountStatus.Scheduled} />,
       );
 
       expect(performance).toContainReactText('Discount is not active yet.');
@@ -32,7 +32,7 @@ describe('<Performance />', () => {
         const performance = mountWithApp(
           <Performance
             {...mockProps}
-            tone={status}
+            status={status}
             usageCount={usageCount}
           />,
         );

--- a/src/components/TimePicker/TimePicker.tsx
+++ b/src/components/TimePicker/TimePicker.tsx
@@ -129,7 +129,7 @@ export function TimePicker({
         <Autocomplete.TextField
           label={label}
           labelHidden={labelHidden}
-          prefix={<Icon source={ClockMinor} color="subdued" />}
+          prefix={<Icon source={ClockMinor} tone="subdued" />}
           placeholder={i18n.translate(
             'DiscountAppComponents.TimePicker.timePlaceholder',
           )}

--- a/src/components/TimePicker/tests/TimePicker.test.tsx
+++ b/src/components/TimePicker/tests/TimePicker.test.tsx
@@ -245,7 +245,7 @@ describe('<TimePicker />', () => {
         Icon,
         {
           source: ClockMinor,
-          color: 'subdued',
+          tone: 'subdued',
         },
       );
     });

--- a/src/components/UsageLimitsCard/UsageLimitsCard.tsx
+++ b/src/components/UsageLimitsCard/UsageLimitsCard.tsx
@@ -143,7 +143,7 @@ export function UsageLimitsCard(props: UsageLimitsCardProps) {
                       </div>
                     )}
                     {isRecurring && (
-                      <Text as="span" color="subdued">
+                      <Text as="span" tone="subdued">
                         {i18n.translate(
                           'DiscountAppComponents.UsageLimitsCard.totalUsageLimitHelpTextSubscription',
                         )}

--- a/src/components/UsageLimitsCard/UsageLimitsCard.tsx
+++ b/src/components/UsageLimitsCard/UsageLimitsCard.tsx
@@ -5,7 +5,7 @@ import {
   TextField,
   Text,
   InlineError,
-  VerticalStack,
+  BlockStack,
   Box,
 } from '@shopify/polaris';
 import {useI18n} from '@shopify/react-i18n';
@@ -98,7 +98,7 @@ export function UsageLimitsCard(props: UsageLimitsCardProps) {
   return (
     <Box paddingBlockEnd="4">
       <Card padding="4">
-        <VerticalStack gap="4">
+        <BlockStack gap="4">
           <Text variant="headingMd" as="h2">
             {i18n.translate('DiscountAppComponents.UsageLimitsCard.title')}
           </Text>
@@ -121,7 +121,7 @@ export function UsageLimitsCard(props: UsageLimitsCardProps) {
                 ),
                 value: UsageLimitType.TotalUsageLimit,
                 renderChildren: (isSelected: boolean) => (
-                  <VerticalStack>
+                  <BlockStack>
                     {isSelected && (
                       <div className={styles.TotalUsageLimitTextField}>
                         <TextField
@@ -155,7 +155,7 @@ export function UsageLimitsCard(props: UsageLimitsCardProps) {
                         message={totalUsageLimit.error}
                       />
                     )}
-                  </VerticalStack>
+                  </BlockStack>
                 ),
               },
               {
@@ -167,14 +167,14 @@ export function UsageLimitsCard(props: UsageLimitsCardProps) {
             ]}
             onChange={handleUsageLimitsChoicesChange}
           />
-        </VerticalStack>
+        </BlockStack>
         {isShowRecurringPaymentSection(props) && (
-          <VerticalStack gap="4">
+          <BlockStack gap="4">
             <RecurringPayment
               recurringPaymentType={props.recurringPaymentType}
               recurringPaymentLimit={props.recurringPaymentLimit}
             />
-          </VerticalStack>
+          </BlockStack>
         )}
       </Card>
     </Box>

--- a/src/components/UsageLimitsCard/components/RecurringPayment/RecurringPayment.tsx
+++ b/src/components/UsageLimitsCard/components/RecurringPayment/RecurringPayment.tsx
@@ -4,7 +4,7 @@ import {
   TextField,
   Text,
   InlineError,
-  VerticalStack,
+  BlockStack,
 } from '@shopify/polaris';
 import {useI18n} from '@shopify/react-i18n';
 
@@ -48,7 +48,7 @@ export function RecurringPayment({
       renderChildren: (isSelected: boolean) => {
         return (
           isSelected && (
-            <VerticalStack gap="4">
+            <BlockStack gap="4">
               <div className={styles.RecurringPaymentTextField}>
                 <TextField
                   id={RECURRING_PAYMENT_FIELD_ID}
@@ -78,7 +78,7 @@ export function RecurringPayment({
                   message={recurringPaymentLimit.error}
                 />
               )}
-            </VerticalStack>
+            </BlockStack>
           )
         );
       },
@@ -92,7 +92,7 @@ export function RecurringPayment({
   ];
 
   return (
-    <VerticalStack gap="4">
+    <BlockStack gap="4">
       <Text variant="headingXs" as="h3">
         {i18n.translate('DiscountAppComponents.RecurringPayment.title')}
       </Text>
@@ -107,6 +107,6 @@ export function RecurringPayment({
           )
         }
       />
-    </VerticalStack>
+    </BlockStack>
   );
 }

--- a/src/components/UsageLimitsCard/components/RecurringPayment/RecurringPayment.tsx
+++ b/src/components/UsageLimitsCard/components/RecurringPayment/RecurringPayment.tsx
@@ -67,7 +67,7 @@ export function RecurringPayment({
                   error={Boolean(recurringPaymentLimit.error)}
                 />
               </div>
-              <Text as="span" color="subdued">
+              <Text as="span" tone="subdued">
                 {i18n.translate(
                   'DiscountAppComponents.RecurringPayment.includesFirstPayment',
                 )}

--- a/src/components/UsageLimitsCard/components/RecurringPayment/tests/RecurringPayment.test.tsx
+++ b/src/components/UsageLimitsCard/components/RecurringPayment/tests/RecurringPayment.test.tsx
@@ -4,7 +4,7 @@ import {
   TextField,
   InlineError,
   Text,
-  VerticalStack,
+  BlockStack,
 } from '@shopify/polaris';
 import {mockField, mountWithApp} from 'tests/utilities';
 
@@ -22,7 +22,7 @@ describe('<RecurringPayment />', () => {
       <RecurringPayment {...defaultProps} />,
     );
 
-    const container = recurringPayment.find(VerticalStack);
+    const container = recurringPayment.find(BlockStack);
 
     expect(container).toContainReactComponent(Text, {
       children: 'Recurring payments for subscriptions',

--- a/src/components/UsageLimitsCard/tests/UsageLimitsCard.test.tsx
+++ b/src/components/UsageLimitsCard/tests/UsageLimitsCard.test.tsx
@@ -4,7 +4,7 @@ import {
   TextField,
   Card,
   InlineError,
-  VerticalStack,
+  BlockStack,
   Text,
 } from '@shopify/polaris';
 import {mockField, mountWithApp} from 'tests/utilities';
@@ -89,7 +89,7 @@ describe('UsageLimitsCard', () => {
     it('displays usage limit option in a stack', () => {
       const usageLimits = mountWithApp(<UsageLimitsCard {...defaultProps} />);
 
-      expect(usageLimits).toContainReactComponent(VerticalStack);
+      expect(usageLimits).toContainReactComponent(BlockStack);
     });
 
     it('displays total usage limit text field when totalUsageLimit is a number', () => {
@@ -101,7 +101,7 @@ describe('UsageLimitsCard', () => {
         />,
       );
 
-      const stack = usageLimits.find(VerticalStack);
+      const stack = usageLimits.find(BlockStack);
 
       expect(stack).toContainReactComponent(TextField, {
         value: totalUsageLimit,
@@ -118,7 +118,7 @@ describe('UsageLimitsCard', () => {
         />,
       );
 
-      const stack = usageLimits.find(VerticalStack);
+      const stack = usageLimits.find(BlockStack);
 
       expect(stack).toContainReactComponent(Text, {
         children: 'A subscription with many payments will count as one use.',

--- a/src/components/ValueCard/ValueCard.tsx
+++ b/src/components/ValueCard/ValueCard.tsx
@@ -5,9 +5,9 @@ import {
   Checkbox,
   ChoiceList,
   InlineError,
-  VerticalStack,
+  BlockStack,
   TextField,
-  HorizontalStack,
+  InlineStack,
   Box,
   Card,
   Text,
@@ -105,11 +105,11 @@ export function ValueCard({
   return (
     <Box paddingBlockEnd="4">
       <Card padding="4">
-        <VerticalStack gap="2">
+        <BlockStack gap="2">
           <Text variant="headingMd" as="h2">
             {i18n.translate('DiscountAppComponents.ValueCard.title')}{' '}
           </Text>
-          <HorizontalStack gap="3" align="start">
+          <InlineStack gap="3" align="start">
             <ButtonGroup segmented>
               <Button
                 size="large"
@@ -184,7 +184,7 @@ export function ValueCard({
                 </div>
               )}
             </Box>
-          </HorizontalStack>
+          </InlineStack>
           {sellsSubscriptions && (
             <>
               <Text variant="headingMd" as="h2">
@@ -249,7 +249,7 @@ export function ValueCard({
               collectionSelector={collectionSelector}
             />
           ) : null}
-        </VerticalStack>
+        </BlockStack>
       </Card>
     </Box>
   );

--- a/src/components/ValueCard/ValueCard.tsx
+++ b/src/components/ValueCard/ValueCard.tsx
@@ -110,7 +110,7 @@ export function ValueCard({
             {i18n.translate('DiscountAppComponents.ValueCard.title')}{' '}
           </Text>
           <InlineStack gap="3" align="start">
-            <ButtonGroup segmented>
+            <ButtonGroup variant='segmented'>
               <Button
                 size="large"
                 pressed={isPercentageDiscount}

--- a/src/stories/patterns/AppliesToPattern/AppliesToPattern.tsx
+++ b/src/stories/patterns/AppliesToPattern/AppliesToPattern.tsx
@@ -2,7 +2,7 @@ import React, {useState, useEffect} from 'react';
 import {
   Page,
   Modal,
-  HorizontalStack,
+  InlineStack,
   Button,
   ChoiceList,
 } from '@shopify/polaris';
@@ -116,9 +116,9 @@ export function ItemModal({
   return (
     <Modal
       activator={
-        <HorizontalStack>
+        <InlineStack>
           <Button onClick={toggleModal}>Browse</Button>
-        </HorizontalStack>
+        </InlineStack>
       }
       open={open}
       onClose={handleClose}

--- a/src/stories/patterns/DiscountPagePattern/DiscountPagePattern.tsx
+++ b/src/stories/patterns/DiscountPagePattern/DiscountPagePattern.tsx
@@ -236,7 +236,7 @@ export default function DiscountPage({id = '1'}) {
             timezoneAbbreviation={timezoneAbbreviation}
           />
         </Layout.Section>
-        <Layout.Section secondary>
+        <Layout.Section variant='oneThird'>
           <SummaryCard
             header={{
               discountMethod: discountMethod,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2875,23 +2875,30 @@
     fs-extra "^9.0.0"
     glob "^7.1.6"
 
-"@shopify/polaris-icons@^7.1.0", "@shopify/polaris-icons@^7.7.0":
+"@shopify/polaris-icons@^7.1.0":
   version "7.8.1"
   resolved "https://registry.yarnpkg.com/@shopify/polaris-icons/-/polaris-icons-7.8.1.tgz#06f304a9cee40a414e87278ebc3eabb180006bcf"
   integrity sha512-3qg3tzLEzeKzAcVcswNtdAoY+YNk0zq7Q0BUYzCQrr8InJqxMTrbihbVVxJ9209onfh/eosMacmzM2CHx3xjeQ==
 
-"@shopify/polaris-tokens@^7.5.2":
-  version "7.5.2"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris-tokens/-/polaris-tokens-7.5.2.tgz#6ab5308dfdcf912e01e60b659060bd10678b7b91"
-  integrity sha512-xEpIhwqR1RHVjY4YGeZd4In8NrjE5IHunyvXtbXrZZ75ydCqP7GYIhC8JSB8OyEx9eb4R4ERRgLyhYnDLG0TYA==
+"@shopify/polaris-icons@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris-icons/-/polaris-icons-7.9.0.tgz#2c7ec5b5cf2d68c6252bf9992c4604a2def596c3"
+  integrity sha512-JSn8tg5c6cWiKqOJE1757kuK8JKP9NGpwIp9Li2gEIA/PP4LL8RHMYOIuH3RS/yQO3pEhVsHnnlVFvREate8ng==
 
-"@shopify/polaris@^12.0.0-beta.0":
-  version "12.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris/-/polaris-12.0.0-beta.0.tgz#274ab7313f862c35597f9588a48c93458c8a720e"
-  integrity sha512-/AZKs9GWPLfoxQw65bU8svohC3bi0CIDyU+6jGwciS5iJB5yU07XumNkuk6adKqRcaxFallN+j2tTNSbw+LG7g==
+"@shopify/polaris-tokens@^7.13.0-beta.0":
+  version "7.13.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris-tokens/-/polaris-tokens-7.13.0-beta.0.tgz#6f40d12a29eccade85ca7d2cd67bdd23b62a227b"
+  integrity sha512-RQXd2FTNzTI/jHzFP3uUm0T9++oiC7vmZLyNACoFwO0tY56io9ukrFCnVnFPwoefJh3tyvb7ZWTQTApQgR7UUw==
   dependencies:
-    "@shopify/polaris-icons" "^7.7.0"
-    "@shopify/polaris-tokens" "^7.5.2"
+    deepmerge "^4.3.1"
+
+"@shopify/polaris@^12.0.0-beta.1":
+  version "12.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris/-/polaris-12.0.0-beta.1.tgz#f1f77947479e84e8c2443bc9bcc0d9d62c9a8f9c"
+  integrity sha512-AHQUSG7uqrYrz0MmwaV3xHXO+IZdeow8Ezu+DIbQFREUz2ODBbjwCIbbf58K5xgZVXy9VnTPlyw0HCk5hRks1Q==
+  dependencies:
+    "@shopify/polaris-icons" "^7.9.0"
+    "@shopify/polaris-tokens" "^7.13.0-beta.0"
     "@types/react" "^18.2.0"
     "@types/react-dom" "^18.2.0"
     "@types/react-transition-group" "^4.4.2"
@@ -6707,7 +6714,7 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
-deepmerge@^4.2.2:
+deepmerge@^4.2.2, deepmerge@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
   integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==


### PR DESCRIPTION
### What problem is this PR solving?

Polaris beta-1 introduced some changes to component and prop naming. Namely:

`VerticalStack` -> `BlockStack`
`HorizontalStack` -> `InlineStack`
`color` && `status` -> `tone`
`<Layout.Section secondary>` -> `<Layout.Section variant='oneThird'>`
`<Button plain />` -> `<Button variant='plain'>`

### Reviewers’ hat-rack :tophat:

I've sanity checked everything on Storybook looks good - but it would probably be wise to have a second pair of eyes 👁️ 👁️ .

### Before you deploy

> **Warning**
> With every PR, you **MUST** think through each of the items in the following checklist and check the appropriate ones. This step cannot be overlooked by the **PR author** or its **reviewers**. Please remove this warning when you're done.

- [X] This PR is safe to rollback.
- [X] I tophatted this change on Storybook.
