### PR TITLE
fix: revert to non-shopify job for cla workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   cla:
-    runs-on: shopify-ubuntu-latest
+    runs-on: ubuntu-latest
     if: |
       (github.event.issue.pull_request
         && !github.event.issue.pull_request.merged_at


### PR DESCRIPTION
### What problem is this PR solving?

the CLA workflow was failing to lookup IP addresses initially, and it seemed like the right approach was to use shopify-ubuntu-latest based on some threads in slack. This appears to have made it worse (the runner is not found at all for the workflow), which I am now seeing in a discourse thread we should not be using this workflow runner in public repos >.< 

https://discourse.shopify.io/t/ip-address-restriction-error-for-cla-workflow-with-public-github-repos/40836/6

original commit: https://github.com/Shopify/discount-app-components/pull/177/commits/0dd2f5a3e33c2ca9755f234ed42eed82f259758a

![image](https://github.com/Shopify/discount-app-components/assets/88739497/e1a02fe1-49ee-4385-a432-394e711c4ef3)

<!-- Provide before and after screenshots of the changes you're proposing to introduce if it applies -->

### Reviewers’ hat-rack :tophat:

<!--
- Tophatting instructions
- What you want reviewers to concentrate on?
-->

### Before requesting reviews

<!-- Please review our [contribution guidelines](CONTRIBUTING.md). -->

<!--- If your changes require a changeset, please create one by running `yarn changeset add` and commit the generated changesets. If you don't want to include those changes in the changelog, you can label your pr with 🤖 Skip Changelog. -->

### Before you deploy

> **Warning**
> With every PR, you **MUST** think through each of the items in the following checklist and check the appropriate ones. This step cannot be overlooked by the **PR author** or its **reviewers**. Please remove this warning when you're done.

- [x] This PR is safe to rollback.
- [x] I tophatted this change on Storybook.
