### PR TITLE
fix: move strategy to constants

### DIFF
--- a/.changeset/ninety-tables-grin.md
+++ b/.changeset/ninety-tables-grin.md
@@ -1,0 +1,5 @@
+---
+'@shopify/discount-app-components': patch
+---
+
+move strategy to constants

--- a/src/components/DiscountApplicationStrategyCard/DiscountApplicationStrategyCard.tsx
+++ b/src/components/DiscountApplicationStrategyCard/DiscountApplicationStrategyCard.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import {Box, Card, ChoiceList, Text, BlockStack} from '@shopify/polaris';
 import {useI18n} from '@shopify/react-i18n';
 
-import {DiscountApplicationStrategy, Field} from '../../types';
-import {DiscountClass} from '../../constants';
+import {Field} from '../../types';
+import {DiscountClass, DiscountApplicationStrategy} from '../../constants';
 
 export interface DiscountAppStrategyProps {
   /**

--- a/src/components/DiscountApplicationStrategyCard/tests/DiscountApplicationStrategyCard.test.tsx
+++ b/src/components/DiscountApplicationStrategyCard/tests/DiscountApplicationStrategyCard.test.tsx
@@ -3,8 +3,7 @@ import {ChoiceList, TextField} from '@shopify/polaris';
 import {mockField, mountWithApp} from 'tests/utilities';
 
 import {DiscountApplicationStrategyCard} from '../DiscountApplicationStrategyCard';
-import {DiscountApplicationStrategy} from '../../../types';
-import {DiscountClass} from '../../../constants';
+import {DiscountClass, DiscountApplicationStrategy} from '../../../constants';
 
 describe('<DiscountApplicationStrategyCard />', () => {
   const mockProps = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -323,3 +323,9 @@ export enum DiscountValueType {
   Percentage = 'PERCENTAGE',
   FixedAmount = 'FIXED_AMOUNT',
 }
+
+export enum DiscountApplicationStrategy {
+  First = 'FIRST',
+  Maximum = 'MAXIMUM',
+  All = 'ALL',
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,6 @@ export type {
   CustomerSegment,
   CombinableDiscountTypes,
   CombinableDiscountCounts,
-  DiscountApplicationStrategy,
 } from './types';
 
 // constants
@@ -32,6 +31,7 @@ export {
   DiscountStatus,
   Eligibility,
   PurchaseType,
+  DiscountApplicationStrategy,
 } from './constants';
 
 // provider

--- a/src/stories/patterns/DiscountApplicationStrategyCardPattern/DiscountApplicationStrategyCardPattern.tsx
+++ b/src/stories/patterns/DiscountApplicationStrategyCardPattern/DiscountApplicationStrategyCardPattern.tsx
@@ -2,8 +2,7 @@ import React, {useState} from 'react';
 
 import {Page} from '@shopify/polaris';
 import {DiscountApplicationStrategyCard} from '../../../components/DiscountApplicationStrategyCard';
-import {DiscountApplicationStrategy} from '../../../types';
-import {DiscountClass} from '../../../constants';
+import {DiscountClass, DiscountApplicationStrategy} from '../../../constants';
 
 interface Props {
   discountClass: DiscountClass;

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,11 +84,6 @@ export interface CombinableDiscountCounts {
 
 export type CountryCode = SupportedCountryCode | typeof REST_OF_WORLD;
 
-export enum DiscountApplicationStrategy {
-  First = 'FIRST',
-  Maximum = 'MAXIMUM',
-  All = 'ALL',
-}
 export interface ProductOrCollectionResource extends Resource {
   title: string;
 }


### PR DESCRIPTION
### What problem is this PR solving?

moved enum to where it belongs. TIL enum's are constants, or was reminded at least 😆 

### Reviewers’ hat-rack :tophat:

<!--
- Tophatting instructions
- What you want reviewers to concentrate on?
-->

### Before requesting reviews

<!-- Please review our [contribution guidelines](CONTRIBUTING.md). -->

<!--- If your changes require a changeset, please create one by running `yarn changeset add` and commit the generated changesets. If you don't want to include those changes in the changelog, you can label your pr with 🤖 Skip Changelog. -->

### Before you deploy

> **Warning**
> With every PR, you **MUST** think through each of the items in the following checklist and check the appropriate ones. This step cannot be overlooked by the **PR author** or its **reviewers**. Please remove this warning when you're done.

- [x] This PR is safe to rollback.
- [x] I tophatted this change on Storybook.
